### PR TITLE
Support Standalone Execution for Resource Downloader

### DIFF
--- a/butler.py
+++ b/butler.py
@@ -30,7 +30,15 @@ logging.basicConfig(
 logger = logging.getLogger("ButlerHub")
 
 def main():
+    if "--run" in sys.argv:
+        idx = sys.argv.index("--run")
+        if idx + 1 < len(sys.argv) and sys.argv[idx + 1] == "downloader":
+            from skills.downloader.run import main as run_downloader
+            run_downloader()
+            return
+
     parser = argparse.ArgumentParser(description="Butler 资产同步中心 (Asset Sync Hub)")
+    parser.add_argument("--run", choices=["downloader"], help="拉起并独立运行特定的 Butler 模块/技能 (例如: downloader)")
     subparsers = parser.add_subparsers(dest="command", help="子命令")
 
     # Sync

--- a/skills/downloader/__init__.py
+++ b/skills/downloader/__init__.py
@@ -29,11 +29,65 @@ logger = logging.getLogger("DownloaderSkill")
 
 # Path Configuration
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-DOWNLOADS_DIR = os.path.join(PROJECT_ROOT, "data", "downloads")
-CONFIG_PATH = os.path.join(PROJECT_ROOT, "skills", "downloader", "tasks.json")
+SKILL_DIR = os.path.join(PROJECT_ROOT, "skills", "downloader")
+DATA_DIR = os.path.join(SKILL_DIR, "data")
+os.makedirs(DATA_DIR, exist_ok=True)
 
-os.makedirs(DOWNLOADS_DIR, exist_ok=True)
-os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+CONFIG_PATH = os.path.join(DATA_DIR, "tasks.json")
+OLD_CONFIG_PATH = os.path.join(SKILL_DIR, "tasks.json")
+
+# Migrate old tasks.json if it exists and the new one doesn't
+if os.path.exists(OLD_CONFIG_PATH) and not os.path.exists(CONFIG_PATH):
+    try:
+        shutil.move(OLD_CONFIG_PATH, CONFIG_PATH)
+    except Exception:
+        pass
+
+# Local config & standalone settings helper
+LOCAL_CONFIG_PATH = os.path.join(DATA_DIR, "config.json")
+IS_STANDALONE = False
+
+def get_standalone_status() -> bool:
+    global IS_STANDALONE
+    return IS_STANDALONE or os.environ.get("BUTLER_DOWNLOADER_STANDALONE") == "1"
+
+def load_local_config() -> Dict[str, Any]:
+    if not os.path.exists(LOCAL_CONFIG_PATH):
+        return {}
+    try:
+        with open(LOCAL_CONFIG_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+def save_local_config(config: Dict[str, Any]):
+    try:
+        with open(LOCAL_CONFIG_PATH, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=4, ensure_ascii=False)
+    except Exception:
+        pass
+
+def get_downloads_dir() -> str:
+    cfg = load_local_config()
+    custom_path = cfg.get("download_path")
+    if custom_path:
+        # Standardize path
+        custom_path = os.path.expanduser(custom_path)
+        if not os.path.isabs(custom_path):
+            custom_path = os.path.abspath(os.path.join(PROJECT_ROOT, custom_path))
+        os.makedirs(custom_path, exist_ok=True)
+        return custom_path
+
+    # Defaults
+    if get_standalone_status():
+        path = os.path.join(SKILL_DIR, "downloads")
+    else:
+        path = os.path.join(PROJECT_ROOT, "data", "downloads")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+# Legacy compatibility global variable (evaluated once at load)
+DOWNLOADS_DIR = get_downloads_dir()
 
 # Global variables
 streaming_server_port = 8329
@@ -739,7 +793,35 @@ def handle_request(action: str, **kwargs) -> Any:
     # Access Jarvis references
     jarvis_app = kwargs.get("jarvis_app")
 
-    if action == "list_tasks":
+    if action == "get_status":
+        return {
+            "status": "ok",
+            "standalone": get_standalone_status(),
+            "download_path": get_downloads_dir(),
+            "config": load_local_config()
+        }
+
+    elif action == "save_settings":
+        download_path = kwargs.get("download_path")
+        if download_path:
+            download_path = download_path.strip()
+            try:
+                os.makedirs(os.path.expanduser(download_path), exist_ok=True)
+            except Exception as e:
+                return {"status": "error", "error": f"无效或无权限的路径: {str(e)}"}
+
+        cfg = load_local_config()
+        if download_path is not None:
+            cfg["download_path"] = download_path
+
+        for k in ["max_threads", "speed_limit", "server_chan", "push_plus"]:
+            if k in kwargs:
+                cfg[k] = kwargs[k]
+
+        save_local_config(cfg)
+        return {"status": "ok", "config": cfg}
+
+    elif action == "list_tasks":
         return load_tasks()
 
     elif action == "add_task":
@@ -800,7 +882,7 @@ def handle_request(action: str, **kwargs) -> Any:
             name = os.path.basename(parsed.path) or "downloaded_file"
 
         task_id = f"dl_{int(time.time() * 1000)}"
-        file_path = os.path.join(DOWNLOADS_DIR, name)
+        file_path = os.path.join(get_downloads_dir(), name)
 
         tasks = load_tasks()
         tasks[task_id] = {
@@ -1228,6 +1310,14 @@ def handle_request(action: str, **kwargs) -> Any:
             "destination": f"{drive_id}:{dest_path}/{file_name}",
             "size": format_bytes(file_size)
         }
+
+    elif action == "run":
+        try:
+            import skills.downloader.run as run_module
+            run_module.main()
+            return {"status": "ok"}
+        except Exception as e:
+            return {"error": f"Failed to start standalone downloader: {str(e)}"}
 
     return {"error": f"Unknown action: {action}"}
 

--- a/skills/downloader/data/config.json
+++ b/skills/downloader/data/config.json
@@ -1,0 +1,7 @@
+{
+    "download_path": "/home/jules/Downloads/CustomStore",
+    "max_threads": 16,
+    "speed_limit": 200,
+    "server_chan": "",
+    "push_plus": ""
+}

--- a/skills/downloader/run.py
+++ b/skills/downloader/run.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import subprocess
+import threading
+import time
+import webbrowser
+import socket
+
+# Ensure dependencies are satisfied
+def ensure_dependencies():
+    missing = []
+    try:
+        import yaml
+    except ImportError:
+        missing.append("pyyaml")
+    try:
+        import requests
+    except ImportError:
+        missing.append("requests")
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError:
+        missing.append("beautifulsoup4")
+
+    if missing:
+        print(f"检测到缺少以下依赖: {', '.join(missing)}")
+        print("正在为您自动安装必要依赖，请稍等...")
+        try:
+            subprocess.run([sys.executable, "-m", "pip", "install"] + missing, check=True)
+            print("依赖安装成功！")
+        except subprocess.CalledProcessError as e:
+            print(f"自动安装依赖失败: {e}")
+            print("您可能需要手动运行: pip install " + " ".join(missing))
+            print("继续尝试启动...")
+
+ensure_dependencies()
+
+# Add repository root to sys.path to allow correct module resolution
+script_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(os.path.dirname(script_dir))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+# Set standalone env flag
+os.environ["BUTLER_DOWNLOADER_STANDALONE"] = "1"
+
+# Import downloader skill
+try:
+    import skills.downloader as downloader
+except ImportError:
+    # Fallback absolute path import if sys.path resolves differently
+    sys.path.insert(0, os.path.dirname(script_dir))
+    import downloader
+
+# Explicitly flag standalone inside module
+downloader.IS_STANDALONE = True
+
+def find_available_port(start_port=8329, max_port=8340):
+    for port in range(start_port, max_port + 1):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("", port))
+                return port
+            except OSError:
+                continue
+    raise OSError("未找到可用的端口！")
+
+def main():
+    print("=" * 60)
+    print("      Butler 资源下载器 - 独立运行模式 (Standalone)")
+    print("=" * 60)
+
+    # Find available port
+    try:
+        port = find_available_port()
+    except OSError as e:
+        print(f"❌ 启动失败: {e}")
+        sys.exit(1)
+
+    # Initialize downloader settings & daemon threads
+    downloader.streaming_server_port = port
+
+    # Start scheduler daemon
+    downloader.scheduler_thread = threading.Thread(target=downloader.run_scheduler_daemon, daemon=True)
+    downloader.scheduler_thread.start()
+
+    url = f"http://localhost:{port}/ui/index.html"
+    print(f"🚀 服务已拉起，正在自动打开浏览器...")
+    print(f"🔗 UI 面板地址: {url}")
+    print(f"📂 默认下载路径: {downloader.get_downloads_dir()}")
+    print("按下 Ctrl+C 可停止运行。")
+    print("=" * 60)
+
+    # Open browser automatically with a slight delay
+    def open_browser():
+        time.sleep(1.2)
+        try:
+            webbrowser.open(url)
+        except Exception:
+            pass
+
+    threading.Thread(target=open_browser, daemon=True).start()
+
+    # Launch server blockingly
+    import http.server
+    try:
+        httpd = http.server.ThreadingHTTPServer(("", port), downloader.SafeHTTPRangeHandler)
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\n服务已停止。感谢您的使用！")
+    except Exception as e:
+        print(f"服务异常终止: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/skills/downloader/ui/index.html
+++ b/skills/downloader/ui/index.html
@@ -115,13 +115,13 @@
                 <i class="fas fa-download text-xl"></i>
             </div>
             <div>
-                <h1 class="text-xl md:text-2xl font-bold tracking-wide">资源下载器 <span class="text-xs font-semibold bg-blue-500 text-white px-2 py-0.5 rounded-full uppercase ml-1">v2.0</span></h1>
+                <h1 class="text-xl md:text-2xl font-bold tracking-wide">资源下载器 <span class="text-xs font-semibold bg-blue-500 text-white px-2 py-0.5 rounded-full uppercase ml-1">v2.0</span><span id="standalone-badge" class="text-xs font-bold bg-indigo-600 text-white px-2 py-0.5 rounded-full uppercase ml-1.5 hidden">Standalone</span></h1>
                 <p class="text-xs text-gray-400">快 • 稳 • 全 — 纯净高效的多线程并发与跨端同步中心</p>
             </div>
         </div>
         <!-- Global Actions and Status -->
         <div class="flex items-center space-x-3">
-            <button onclick="window.history.back()" class="px-4 py-2 rounded-lg text-sm bg-gray-800 hover:bg-gray-700 transition flex items-center space-x-2">
+            <button id="btn-back-home" onclick="window.history.back()" class="px-4 py-2 rounded-lg text-sm bg-gray-800 hover:bg-gray-700 transition flex items-center space-x-2">
                 <i class="fas fa-arrow-left"></i> <span>返回主页</span>
             </button>
             <div id="scheduler-badge" class="px-3 py-1.5 rounded-full text-xs font-bold bg-green-500 bg-opacity-20 text-green-400 border border-green-500 border-opacity-30 flex items-center space-x-1.5">
@@ -374,6 +374,10 @@
                             <input type="number" id="settings-speedlimit" class="w-full bg-gray-900 border border-gray-800 rounded-xl p-2.5 text-sm text-gray-100" value="200">
                         </div>
                     </div>
+                    <div class="mt-4">
+                        <label class="block text-xs text-gray-400 mb-1">默认下载保存路径</label>
+                        <input type="text" id="settings-downloadpath" class="w-full bg-gray-900 border border-gray-800 rounded-xl p-2.5 text-sm text-gray-100 font-mono" placeholder="不填则使用系统默认相对路径">
+                    </div>
                 </div>
 
                 <div class="space-y-4">
@@ -500,7 +504,72 @@
 
             // Set up real-time inputs decoders
             setupUrlInputDecoder();
+
+            // Check standalone status
+            checkStandaloneStatus();
         });
+
+        // Check if running in standalone mode or inside Butler
+        async function checkStandaloneStatus() {
+            const status = await callSkillBackend('get_status');
+            if (status && status.status === 'ok') {
+                if (status.standalone) {
+                    // Standalone mode UI optimization
+                    const btnBackHome = document.getElementById('btn-back-home');
+                    if (btnBackHome) btnBackHome.classList.add('hidden');
+
+                    const badge = document.getElementById('standalone-badge');
+                    if (badge) badge.classList.remove('hidden');
+
+                    // Hide storage tab in standalone mode to keep grid layout clean and precise
+                    const tabStorage = document.getElementById('tab-storage');
+                    if (tabStorage) tabStorage.classList.add('hidden');
+
+                    // Adjust grid classes for tabs if storage is hidden
+                    const navContainer = tabStorage ? tabStorage.parentElement : null;
+                    if (navContainer) {
+                        navContainer.classList.remove('md:grid-cols-6');
+                        navContainer.classList.add('md:grid-cols-5');
+                    }
+                } else {
+                    const btnBackHome = document.getElementById('btn-back-home');
+                    if (btnBackHome) btnBackHome.classList.remove('hidden');
+
+                    const badge = document.getElementById('standalone-badge');
+                    if (badge) badge.classList.add('hidden');
+
+                    const tabStorage = document.getElementById('tab-storage');
+                    if (tabStorage) tabStorage.classList.remove('hidden');
+                }
+
+                // Populate customized settings fields
+                if (status.download_path) {
+                    const pathInput = document.getElementById('settings-downloadpath');
+                    if (pathInput) pathInput.value = status.download_path;
+                }
+
+                // Populate configs
+                if (status.config) {
+                    const cfg = status.config;
+                    if (cfg.max_threads) {
+                        const threadsInput = document.getElementById('settings-threads');
+                        if (threadsInput) threadsInput.value = cfg.max_threads;
+                    }
+                    if (cfg.speed_limit) {
+                        const limitInput = document.getElementById('settings-speedlimit');
+                        if (limitInput) limitInput.value = cfg.speed_limit;
+                    }
+                    if (cfg.server_chan) {
+                        const scInput = document.getElementById('settings-serverchan');
+                        if (scInput) scInput.value = cfg.server_chan;
+                    }
+                    if (cfg.push_plus) {
+                        const ppInput = document.getElementById('settings-pushplus');
+                        if (ppInput) ppInput.value = cfg.push_plus;
+                    }
+                }
+            }
+        }
 
         // Auto decode Thunder link on paste
         function setupUrlInputDecoder() {
@@ -539,17 +608,39 @@
 
         // Call python skills securely
         async function callSkillBackend(action, params = {}) {
-            if (isMock) {
-                // Fallback mock values in browser sandbox mode
-                console.log(`Mock calling downloader:${action}`, params);
-                return getMockResponse(action, params);
+            // 1. If pywebview is available, use it
+            if (typeof window.pywebview !== 'undefined' && typeof window.pywebview.api !== 'undefined') {
+                try {
+                    return await window.pywebview.api.call_skill('downloader', action, params);
+                } catch (err) {
+                    console.error("Pywebview backend call error", err);
+                    return { error: err.toString() };
+                }
             }
-            try {
-                return await window.pywebview.api.call_skill('downloader', action, params);
-            } catch (err) {
-                console.error("Pywebview backend call error", err);
-                return { error: err.toString() };
+
+            // 2. Otherwise, check if we are served from http/https server and use fetch API
+            if (window.location.protocol.startsWith('http')) {
+                try {
+                    const response = await fetch(`/api/${action}`, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify(params)
+                    });
+                    if (response.ok) {
+                        return await response.json();
+                    } else {
+                        console.warn(`HTTP API call error: ${response.status}`);
+                    }
+                } catch (err) {
+                    console.error("Fetch API backend call error", err);
+                }
             }
+
+            // 3. Fallback mock values in browser sandbox mode
+            console.log(`Mock calling downloader:${action}`, params);
+            return getMockResponse(action, params);
         }
 
         // Dynamic stats task list fetcher
@@ -1048,14 +1139,29 @@
             const limit = document.getElementById('settings-speedlimit').value;
             const sc = document.getElementById('settings-serverchan').value;
             const pp = document.getElementById('settings-pushplus').value;
+            const dlPath = document.getElementById('settings-downloadpath').value;
 
             // Simple local cache save
             localStorage.setItem('downloader_threads', threads);
             localStorage.setItem('downloader_limit', limit);
             localStorage.setItem('downloader_sc', sc);
             localStorage.setItem('downloader_pp', pp);
+            localStorage.setItem('downloader_path', dlPath);
 
-            showToast("保存成功", "下载配置及微信推送 Key 缓存保存成功！");
+            // Call backend save_settings to persist in config.json
+            const res = await callSkillBackend('save_settings', {
+                download_path: dlPath,
+                max_threads: parseInt(threads) || 16,
+                speed_limit: parseInt(limit) || 200,
+                server_chan: sc,
+                push_plus: pp
+            });
+
+            if (res && res.status === 'error') {
+                showToast("保存失败", res.error, "error");
+            } else {
+                showToast("保存成功", "下载配置及保存路径已成功写入服务器配置！");
+            }
         }
 
         // Format helpers

--- a/verification/test_downloader_backend.py
+++ b/verification/test_downloader_backend.py
@@ -93,5 +93,31 @@ class TestDownloaderBackend(unittest.TestCase):
         self.assertGreater(len(drives), 0)
         self.assertIn("name", drives[0])
 
+    def test_standalone_status(self):
+        """Test that get_status action returns correct standalone, directory, and config parameters."""
+        res = handle_request("get_status")
+        self.assertEqual(res["status"], "ok")
+        self.assertIn("standalone", res)
+        self.assertIn("download_path", res)
+        self.assertIn("config", res)
+
+    def test_save_settings_and_path_resolution(self):
+        """Test saving customized settings and verifying path resolution updates dynamically."""
+        import tempfile
+        temp_dir = tempfile.mkdtemp()
+        try:
+            res = handle_request("save_settings", download_path=temp_dir, max_threads=8)
+            self.assertEqual(res["status"], "ok")
+            self.assertEqual(res["config"]["download_path"], temp_dir)
+            self.assertEqual(res["config"]["max_threads"], 8)
+
+            status_res = handle_request("get_status")
+            self.assertEqual(status_res["download_path"], temp_dir)
+        finally:
+            if os.path.exists(temp_dir):
+                shutil.rmtree(temp_dir)
+            from skills.downloader import save_local_config
+            save_local_config({})
+
 if __name__ == "__main__":
     unittest.main()

--- a/verification/verify_downloader.py
+++ b/verification/verify_downloader.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import time
+from playwright.sync_api import sync_playwright
+
+def run_cuj(page):
+    # Navigate to the standalone downloader UI
+    print("Navigating to http://localhost:8329/ui/index.html...")
+    page.goto("http://localhost:8329/ui/index.html")
+    page.wait_for_timeout(1000)
+
+    # Verify elements
+    print("Verifying Standalone Badge is visible...")
+    badge_visible = page.is_visible("#standalone-badge")
+    print(f"Standalone Badge visible: {badge_visible}")
+
+    print("Verifying 'Back to Home' button is hidden...")
+    back_visible = page.is_visible("#btn-back-home")
+    print(f"'Back to Home' button visible: {back_visible}")
+
+    # Go to Settings
+    print("Clicking on '设置中心' (Settings Center)...")
+    page.click("#tab-settings")
+    page.wait_for_timeout(800)
+
+    # Focus on path setting and input a custom path
+    print("Entering custom download save path...")
+    page.fill("#settings-downloadpath", "/home/jules/Downloads/CustomStore")
+    page.wait_for_timeout(500)
+
+    # Click Save Settings
+    print("Clicking '保存设置' (Save Settings)...")
+    page.get_by_role("button", name="保存设置").click()
+    page.wait_for_timeout(1500) # Wait for toast message to pop up and hold
+
+    # Take screenshot at the final state
+    screenshot_path = "/home/jules/verification/screenshots/verification.png"
+    page.screenshot(path=screenshot_path)
+    print(f"Screenshot successfully saved to {screenshot_path}")
+    page.wait_for_timeout(1000)
+
+if __name__ == "__main__":
+    os.makedirs("/home/jules/verification/videos", exist_ok=True)
+    os.makedirs("/home/jules/verification/screenshots", exist_ok=True)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            record_video_dir="/home/jules/verification/videos"
+        )
+        page = context.new_page()
+        try:
+            run_cuj(page)
+        except Exception as e:
+            print(f"Error executing CUJ: {e}")
+        finally:
+            context.close()
+            browser.close()


### PR DESCRIPTION
This pull request makes the Butler Resource Downloader support completely standalone execution, either as an independent web application or via Butler's main command lines, preserving Butler's clean folder-local skill architecture. It features automatic dependency checks, auto-opens the browser, uses localized configurations in skills/downloader/data/, and dynamically adapts the frontend UI for standalone use without affecting alignment or layout.

---
*PR created automatically by Jules for task [12428053614734846224](https://jules.google.com/task/12428053614734846224) started by @HelloEveryboby*

## Summary by Sourcery

为 Butler Resource Downloader 添加独立运行支持，包括本地化配置、动态 UI 适配以及专用的运行入口。

New Features:
- 引入一个用于 downloader 技能的独立运行脚本，启动 HTTP 服务器、调度守护进程，并自动打开浏览器 UI。
- 暴露一个新的后端 action，用于以独立模式启动 downloader，以及一个 CLI 标志，用于直接从 Butler 运行 downloader。
- 为 UI 添加对独立模式的检测支持，显示模式徽标、隐藏 hub 相关的导航，并按实例加载配置，包括自定义下载路径。

Enhancements:
- 重构 downloader 配置路径，将其统一放到 `skills/downloader/data/` 下，包括迁移旧有任务文件和新增 JSON 配置存储。
- 增强后端路径解析，以支持可配置的下载目录和基于环境的独立模式检测。
- 改进前端到后端的调用路由，在 `pywebview` 不可用时回退到 HTTP API，再回退到 mocks，以支持沙盒运行场景。

Tests:
- 为 downloader 后端添加单元测试，用于校验独立模式状态上报以及在动态路径解析下的设置持久化。
- 添加基于 Playwright 的验证脚本，用于检查独立运行的 downloader UI 流程及设置保存行为。

Chores:
- 添加空的 `skills/downloader/data/config.json` 文件，用于初始化本地配置存储。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add standalone execution support for the Butler Resource Downloader with localized configuration, dynamic UI adaptation, and a dedicated runner entrypoint.

New Features:
- Introduce a standalone runner script for the downloader skill that launches an HTTP server, scheduler daemon, and auto-opens the browser UI.
- Expose a new backend action to start the downloader in standalone mode and a CLI flag to run the downloader directly from Butler.
- Add UI support for detecting standalone mode, showing a badge, hiding hub-specific navigation, and loading per-instance configuration including a custom download path.

Enhancements:
- Refactor downloader configuration paths to live under skills/downloader/data/, including migration of legacy task files and a new JSON config store.
- Enhance backend path resolution to support configurable download directories and environment-based standalone detection.
- Improve frontend backend-call routing by falling back from pywebview to HTTP APIs and then to mocks for sandboxed use.

Tests:
- Add unit tests for the downloader backend to validate standalone status reporting and settings persistence with dynamic path resolution.
- Add a Playwright-based verification script to exercise the standalone downloader UI flow and settings saving behavior.

Chores:
- Add an empty skills/downloader/data/config.json file to initialize local configuration storage.

</details>