### PR TITLE
Implement High-Fidelity Markdown Multi-Format Exporter and Reverse Document Conversion Suite

### DIFF
--- a/butler.py
+++ b/butler.py
@@ -36,9 +36,13 @@ def main():
             from skills.downloader.run import main as run_downloader
             run_downloader()
             return
+        elif idx + 1 < len(sys.argv) and sys.argv[idx + 1] == "format_convert":
+            from skills.format_convert.run import main as run_format_convert
+            run_format_convert()
+            return
 
     parser = argparse.ArgumentParser(description="Butler 资产同步中心 (Asset Sync Hub)")
-    parser.add_argument("--run", choices=["downloader"], help="拉起并独立运行特定的 Butler 模块/技能 (例如: downloader)")
+    parser.add_argument("--run", choices=["downloader", "format_convert"], help="拉起并独立运行特定的 Butler 模块/技能 (例如: downloader, format_convert)")
     subparsers = parser.add_subparsers(dest="command", help="子命令")
 
     # Sync

--- a/package/document/file_converter.py
+++ b/package/document/file_converter.py
@@ -169,6 +169,45 @@ def convert_file(input_file_path, output_file_path, output_folder):
     input_ext = os.path.splitext(input_file_path)[1].lower()
     output_ext = os.path.splitext(output_file_path)[1].lower()
 
+    # Map extensions to upper format names
+    from_fmt = input_ext[1:].upper()
+    to_fmt = output_ext[1:].upper()
+    if from_fmt in ["MARKDOWN", "HTM"]: from_fmt = "MD" if "M" in from_fmt else "HTML"
+    if to_fmt in ["MARKDOWN", "HTM"]: to_fmt = "MD" if "M" in to_fmt else "HTML"
+    if from_fmt in ["JPEG", "JPG"]: from_fmt = "JPG"
+    if to_fmt in ["JPEG", "JPG"]: to_fmt = "JPG"
+
+    supported_routes = [
+        # MD target exports
+        ("MD", "HTML"), ("MD", "DOCX"), ("MD", "EPUB"), ("MD", "PNG"), ("MD", "JPG"), ("MD", "PDF"),
+        # HTML target exports & reverse
+        ("HTML", "MD"), ("HTML", "DOCX"), ("HTML", "EPUB"), ("HTML", "PDF"),
+        # DOCX target reverse & cross
+        ("DOCX", "MD"), ("DOCX", "HTML"), ("DOCX", "EPUB"),
+        # PDF reverse
+        ("PDF", "MD"), ("PDF", "HTML"), ("PDF", "DOCX"),
+        # Image targets
+        ("PNG", "WEBP"), ("JPG", "WEBP"), ("PNG", "BASE64"), ("JPG", "BASE64")
+    ]
+
+    if (from_fmt, to_fmt) in supported_routes:
+        print(f"[*] Intercepted: Routing to Butler High-Fidelity Converter Engine ({from_fmt} -> {to_fmt})")
+        # Save path construction
+        target_path = os.path.join(output_folder, os.path.basename(output_file_path)) if output_folder else output_file_path
+        from skills.format_convert.format_convert import handle_request
+        kwargs = {
+            "input": input_file_path,
+            "from": from_fmt,
+            "to": to_fmt,
+            "save_to": target_path
+        }
+        res = handle_request(action="run", **kwargs)
+        if isinstance(res, str) and "Success" in res:
+            print(f"[+] Butler High-Fidelity Converter success: {res}")
+            return
+        else:
+            print(f"[-] Butler High-Fidelity conversion failed: {res}. Trying local package/document backup...")
+
     if input_ext == '.pdf' and output_ext == '.docx':
         process_pdf(input_file_path, output_file_path, output_folder)
     elif input_ext == '.docx' and output_ext == '.pdf':

--- a/skills/format_convert/core/__init__.py
+++ b/skills/format_convert/core/__init__.py
@@ -1,0 +1,1 @@
+# Core Markdown Exporters

--- a/skills/format_convert/core/exporter_docx.py
+++ b/skills/format_convert/core/exporter_docx.py
@@ -1,0 +1,361 @@
+import re
+import os
+import logging
+
+logger = logging.getLogger("DocxExporter")
+
+try:
+    from docx import Document
+    from docx.shared import Inches, Pt, RGBColor
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+    from docx.oxml import OxmlElement, parse_xml
+    from docx.oxml.ns import nsdecls, qn
+    DOCX_AVAILABLE = True
+except ImportError:
+    DOCX_AVAILABLE = False
+
+
+def _set_cell_background(cell, color_hex):
+    """Sets background color of a table cell."""
+    tc_pr = cell._tc.get_or_add_tcPr()
+    shd_xml = f'<w:shd {nsdecls("w")} w:fill="{color_hex}"/>'
+    tc_pr.append(parse_xml(shd_xml))
+
+
+def _set_cell_margins(cell, top=100, bottom=100, left=150, right=150):
+    """Sets padding for a table cell in twentieths of a point (dxa)."""
+    tc_pr = cell._tc.get_or_add_tcPr()
+    tc_mar = OxmlElement('w:tcMar')
+    for m, val in [('top', top), ('bottom', bottom), ('left', left), ('right', right)]:
+        node = OxmlElement(f'w:{m}')
+        node.set(qn('w:w'), str(val))
+        node.set(qn('w:type'), 'dxa')
+        tc_mar.append(node)
+    tc_pr.append(tc_mar)
+
+
+def markdown_to_docx(md_text, output_path, opts=None):
+    """
+    Converts Markdown to DOCX with high-fidelity Apple-style minimal aesthetic.
+    Supports headings, lists, bold/italic, code blocks, quote blocks, tables, and rules.
+    """
+    if not DOCX_AVAILABLE:
+        # Graceful fallback: write basic structured text if docx package is missing
+        logger.warning("python-docx is not installed. Saving formatted TXT file as a fallback.")
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write("=== Fallback Document (python-docx not installed) ===\n\n")
+            f.write(md_text)
+        return output_path
+
+    opts = opts or {}
+    theme = opts.get("theme", "apple-light")
+    with_water = opts.get("with_water", False)
+
+    doc = Document()
+
+    # Define Apple aesthetic color palettes
+    if theme == "dark":
+        text_color = RGBColor(0xEE, 0xEE, 0xEE)
+        h1_color = RGBColor(0xFF, 0xFF, 0xFF)
+        quote_bg = "1C1C1E"
+        code_bg = "2C2C2E"
+        bg_color_hex = "121212"
+        # Since standard Word pages are white, we maintain dark elements on light background
+        # or dark background styling if preferred. To keep standard readability, we use dark text design.
+        text_color = RGBColor(0x1D, 0x1D, 0x1F)
+        h1_color = RGBColor(0x1D, 0x1D, 0x1F)
+        quote_bg = "F4F4F4"
+        code_bg = "F5F5F7"
+    else:
+        text_color = RGBColor(0x1D, 0x1D, 0x1F)
+        h1_color = RGBColor(0x1D, 0x1D, 0x1F)
+        quote_bg = "F4F4F4"
+        code_bg = "F5F5F7"
+
+    # Document margins
+    for section in doc.sections:
+        section.top_margin = Inches(1.0)
+        section.bottom_margin = Inches(1.0)
+        section.left_margin = Inches(1.0)
+        section.right_margin = Inches(1.0)
+
+    # Helper to style a run with SF Pro / PingFang style font
+    def apply_font_run(run, size_pt, bold=False, italic=False, color=text_color):
+        run.font.name = 'PingFang SC'
+        run.font.size = Pt(size_pt)
+        run.bold = bold
+        run.italic = italic
+        run.font.color.rgb = color
+        # Set East Asia font specifically
+        rPr = run._r.get_or_add_rPr()
+        rFonts = OxmlElement('w:rFonts')
+        rFonts.set(qn('w:eastAsia'), 'PingFang SC')
+        rFonts.set(qn('w:ascii'), 'SF Pro Text')
+        rFonts.set(qn('w:hAnsi'), 'SF Pro Text')
+        rPr.append(rFonts)
+
+    # Process block markdown
+    lines = md_text.split('\n')
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        if not stripped:
+            i += 1
+            continue
+
+        # Horizontal rule
+        if re.match(r'^(?:-{3,}|\*{3,}|\_{3,})$', stripped):
+            p = doc.add_paragraph()
+            p_format = p.paragraph_format
+            p_format.space_before = Pt(12)
+            p_format.space_after = Pt(12)
+            pBdr = OxmlElement('w:pBdr')
+            bottom = OxmlElement('w:bottom')
+            bottom.set(qn('w:val'), 'single')
+            bottom.set(qn('w:sz'), '6')
+            bottom.set(qn('w:space'), '1')
+            bottom.set(qn('w:color'), 'E5E5EA')
+            pBdr.append(bottom)
+            p._p.get_or_add_pPr().append(pBdr)
+            i += 1
+            continue
+
+        # Fenced Code Block
+        if stripped.startswith("```"):
+            lang = stripped[3:].strip()
+            code_lines = []
+            i += 1
+            while i < len(lines) and not lines[i].strip().startswith("```"):
+                code_lines.append(lines[i])
+                i += 1
+            i += 1 # skip ending ```
+
+            # Render code block inside a styled 1x1 table (like a box)
+            table = doc.add_table(rows=1, cols=1)
+            table.alignment = WD_ALIGN_PARAGRAPH.CENTER
+            cell = table.cell(0, 0)
+            _set_cell_background(cell, code_bg)
+            _set_cell_margins(cell, top=140, bottom=140, left=200, right=200)
+
+            # Set a light gray border for code block
+            tcBorders = OxmlElement('w:tcBorders')
+            for b_name in ['top', 'left', 'bottom', 'right']:
+                b_el = OxmlElement(f'w:{b_name}')
+                b_el.set(qn('w:val'), 'single')
+                b_el.set(qn('w:sz'), '4')
+                b_el.set(qn('w:color'), 'E5E5EA')
+                tcBorders.append(b_el)
+            cell._tc.get_or_add_tcPr().append(tcBorders)
+
+            p = cell.paragraphs[0]
+            p.paragraph_format.space_before = Pt(0)
+            p.paragraph_format.space_after = Pt(0)
+            p.paragraph_format.line_spacing = 1.15
+            run = p.add_run("\n".join(code_lines))
+            apply_font_run(run, 9.5, color=RGBColor(0x3A, 0x3A, 0x3C))
+            run.font.name = 'Courier New'
+            continue
+
+        # Headings
+        heading_match = re.match(r'^(#{1,6})\s+(.*)$', stripped)
+        if heading_match:
+            level = len(heading_match.group(1))
+            title_text = heading_match.group(2)
+            p = doc.add_paragraph()
+            p_format = p.paragraph_format
+
+            if level == 1:
+                p_format.space_before = Pt(18)
+                p_format.space_after = Pt(8)
+                run = p.add_run(title_text)
+                apply_font_run(run, 20, bold=True, color=h1_color)
+            elif level == 2:
+                p_format.space_before = Pt(14)
+                p_format.space_after = Pt(6)
+                run = p.add_run(title_text)
+                apply_font_run(run, 16, bold=True, color=h1_color)
+            elif level == 3:
+                p_format.space_before = Pt(12)
+                p_format.space_after = Pt(4)
+                run = p.add_run(title_text)
+                apply_font_run(run, 13, bold=True, color=h1_color)
+            else:
+                p_format.space_before = Pt(10)
+                p_format.space_after = Pt(4)
+                run = p.add_run(title_text)
+                apply_font_run(run, 11, bold=True, color=h1_color)
+
+            i += 1
+            continue
+
+        # Blockquote (starting with '>')
+        if stripped.startswith(">"):
+            quote_lines = []
+            while i < len(lines) and lines[i].strip().startswith(">"):
+                quote_lines.append(re.sub(r'^>\s*', '', lines[i].strip()))
+                i += 1
+
+            # Quote block layout: 1x1 table with thick left border, gray background
+            table = doc.add_table(rows=1, cols=1)
+            cell = table.cell(0, 0)
+            _set_cell_background(cell, quote_bg)
+            _set_cell_margins(cell, top=100, bottom=100, left=180, right=150)
+
+            # Thick left border, none for others
+            tcBorders = OxmlElement('w:tcBorders')
+            left_b = OxmlElement('w:left')
+            left_b.set(qn('w:val'), 'single')
+            left_b.set(qn('w:sz'), '24') # 3pt
+            left_b.set(qn('w:color'), '007AFF') # Apple Blue accent
+            tcBorders.append(left_b)
+            for b_name in ['top', 'bottom', 'right']:
+                b_el = OxmlElement(f'w:{b_name}')
+                b_el.set(qn('w:val'), 'none')
+                tcBorders.append(b_el)
+            cell._tc.get_or_add_tcPr().append(tcBorders)
+
+            p = cell.paragraphs[0]
+            p.paragraph_format.space_before = Pt(4)
+            p.paragraph_format.space_after = Pt(4)
+            p.paragraph_format.line_spacing = 1.15
+            run = p.add_run("\n".join(quote_lines))
+            apply_font_run(run, 10, italic=True, color=RGBColor(0x55, 0x55, 0x55))
+            continue
+
+        # Tables
+        if stripped.startswith("|") and i < len(lines):
+            # Parse table rows
+            table_rows = []
+            while i < len(lines) and lines[i].strip().startswith("|"):
+                row_stripped = lines[i].strip()
+                # Split and filter empty cells at ends
+                cells = [c.strip() for c in row_stripped.split("|")[1:-1]]
+                table_rows.append(cells)
+                i += 1
+
+            if len(table_rows) > 0:
+                # Filter separator row (e.g. |---|---|)
+                clean_rows = []
+                for idx, r in enumerate(table_rows):
+                    if idx == 1 and all(re.match(r'^:?-+:?$', c) for c in r):
+                        continue
+                    clean_rows.append(r)
+
+                if clean_rows:
+                    cols_count = max(len(r) for r in clean_rows)
+                    word_table = doc.add_table(rows=len(clean_rows), cols=cols_count)
+                    word_table.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+                    for row_idx, r_cells in enumerate(clean_rows):
+                        for col_idx, cell_val in enumerate(r_cells):
+                            if col_idx < len(word_table.columns):
+                                cell = word_table.cell(row_idx, col_idx)
+                                cell.text = ""
+                                _set_cell_margins(cell, top=80, bottom=80, left=100, right=100)
+
+                                p = cell.paragraphs[0]
+                                p.paragraph_format.space_before = Pt(0)
+                                p.paragraph_format.space_after = Pt(0)
+
+                                if row_idx == 0:
+                                    # Header row
+                                    _set_cell_background(cell, "F2F2F7")
+                                    run = p.add_run(cell_val)
+                                    apply_font_run(run, 10, bold=True, color=RGBColor(0x1D, 0x1D, 0x1F))
+                                else:
+                                    # Data row zebra striping
+                                    if row_idx % 2 == 0:
+                                        _set_cell_background(cell, "FAFAFC")
+                                    run = p.add_run(cell_val)
+                                    apply_font_run(run, 10, color=RGBColor(0x3A, 0x3A, 0x3C))
+
+                                # Apply borders to all cells
+                                tcBorders = OxmlElement('w:tcBorders')
+                                for b_name in ['top', 'left', 'bottom', 'right']:
+                                    b_el = OxmlElement(f'w:{b_name}')
+                                    b_el.set(qn('w:val'), 'single')
+                                    b_el.set(qn('w:sz'), '4')
+                                    b_el.set(qn('w:color'), 'E5E5EA')
+                                    tcBorders.append(b_el)
+                                cell._tc.get_or_add_tcPr().append(tcBorders)
+            continue
+
+        # Lists (unordered/ordered)
+        unordered_match = re.match(r'^([\-\*\+])\s+(.*)$', stripped)
+        ordered_match = re.match(r'^(\d+)\.\s+(.*)$', stripped)
+
+        if unordered_match or ordered_match:
+            p = doc.add_paragraph()
+            p_format = p.paragraph_format
+            p_format.space_before = Pt(0)
+            p_format.space_after = Pt(3)
+            p_format.left_indent = Inches(0.25)
+
+            if unordered_match:
+                # Add elegant list bullet
+                run_bullet = p.add_run("•  ")
+                apply_font_run(run_bullet, 11, bold=True, color=RGBColor(0x00, 0x7A, 0xFF))
+                content = unordered_match.group(2)
+            else:
+                num_prefix = ordered_match.group(1)
+                run_num = p.add_run(f"{num_prefix}.  ")
+                apply_font_run(run_num, 11, bold=True, color=RGBColor(0x00, 0x7A, 0xFF))
+                content = ordered_match.group(2)
+
+            _add_formatted_inline(p, content, apply_font_run, text_color)
+            i += 1
+            continue
+
+        # Normal Paragraph
+        p = doc.add_paragraph()
+        p_format = p.paragraph_format
+        p_format.space_before = Pt(0)
+        p_format.space_after = Pt(8)
+        p_format.line_spacing = 1.25
+
+        _add_formatted_inline(p, stripped, apply_font_run, text_color)
+        i += 1
+
+    # Watermark Footer
+    if with_water:
+        section = doc.sections[0]
+        footer = section.footer
+        f_p = footer.paragraphs[0]
+        f_p.alignment = WD_ALIGN_PARAGRAPH.RIGHT
+        run = f_p.add_run("Generated by Butler Document Workspace | Secure Watermarked")
+        apply_font_run(run, 8.5, color=RGBColor(0x8E, 0x8E, 0x93))
+
+    doc.save(output_path)
+    return output_path
+
+
+def _add_formatted_inline(paragraph, text, font_setter, text_color):
+    """Parses and adds inline Markdown formats (bold, italic, inline-code)."""
+    # Regex for bold (**text** or __text__), italic (*text* or _text_), inline code (`code`)
+    pattern = re.compile(r'(\*\*.*?\*\*|__.*?__|`.*?`|\*.*?\*|_.*?_)')
+    parts = pattern.split(text)
+
+    for part in parts:
+        if not part:
+            continue
+        if part.startswith("**") and part.endswith("**"):
+            run = paragraph.add_run(part[2:-2])
+            font_setter(run, 11, bold=True, color=text_color)
+        elif part.startswith("__") and part.endswith("__"):
+            run = paragraph.add_run(part[2:-2])
+            font_setter(run, 11, bold=True, color=text_color)
+        elif part.startswith("*") and part.endswith("*"):
+            run = paragraph.add_run(part[1:-1])
+            font_setter(run, 11, italic=True, color=text_color)
+        elif part.startswith("_") and part.endswith("_"):
+            run = paragraph.add_run(part[1:-1])
+            font_setter(run, 11, italic=True, color=text_color)
+        elif part.startswith("`") and part.endswith("`"):
+            run = paragraph.add_run(part[1:-1])
+            font_setter(run, 10, color=RGBColor(0xC9, 0x3B, 0x75)) # Classic pink code block
+            run.font.name = 'Courier New'
+        else:
+            run = paragraph.add_run(part)
+            font_setter(run, 11, color=text_color)

--- a/skills/format_convert/core/exporter_epub.py
+++ b/skills/format_convert/core/exporter_epub.py
@@ -1,0 +1,269 @@
+import os
+import zipfile
+import re
+import uuid
+import logging
+
+logger = logging.getLogger("EpubExporter")
+
+
+def markdown_to_epub(md_text, output_path, opts=None):
+    """
+    Converts Markdown content into a standards-compliant .epub e-book.
+    Uses pure-Python zipfile compression and standard templates (OEBPS/content.opf/toc.ncx).
+    No heavy C or CLI dependencies (like pandoc) required!
+    """
+    opts = opts or {}
+    title = opts.get("title", "Butler Document Book")
+    author = opts.get("author", "Butler Automation")
+    theme = opts.get("theme", "apple-light")
+
+    # Clean up standard html lines from Markdown
+    # We will build a basic HTML representation of Markdown for chapter text
+    import html
+    body_html = _simple_md_to_html(md_text)
+
+    # Unique IDs for compilation
+    book_id = f"urn:uuid:{uuid.uuid4()}"
+
+    # Standard EPUB elements:
+    # 1. mimetype (MUST be uncompressed and must be the first file in ZIP)
+    # 2. META-INF/container.xml
+    # 3. OEBPS/content.opf
+    # 4. OEBPS/toc.ncx
+    # 5. OEBPS/stylesheet.css
+    # 6. OEBPS/chapter1.xhtml
+
+    container_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+    <rootfiles>
+        <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+    </rootfiles>
+</container>"""
+
+    stylesheet_css = """body {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    margin: 10%;
+    color: #1d1d1f;
+    background-color: #ffffff;
+    line-height: 1.6;
+}
+h1 {
+    font-size: 1.8em;
+    text-align: center;
+    color: #007aff;
+    margin-bottom: 1.5em;
+}
+h2 {
+    font-size: 1.4em;
+    color: #1d1d1f;
+    border-bottom: 1px solid #e5e5ea;
+    padding-bottom: 0.3em;
+}
+p {
+    margin-bottom: 1em;
+    text-indent: 0;
+}
+ul, ol {
+    margin-bottom: 1em;
+    padding-left: 1.5em;
+}
+li {
+    margin-bottom: 0.5em;
+}
+blockquote {
+    border-left: 3px solid #007aff;
+    background-color: #f4f4f4;
+    padding: 0.5em 1em;
+    margin: 1em 0;
+    color: #555555;
+    font-style: italic;
+}
+pre {
+    background-color: #f5f5f7;
+    border: 1px solid #e5e5ea;
+    border-radius: 4px;
+    padding: 1em;
+    overflow-x: auto;
+    font-family: monospace;
+}
+code {
+    font-family: monospace;
+    background-color: #f5f5f7;
+    padding: 0.2em 0.4em;
+    border-radius: 3px;
+}
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1.5em 0;
+}
+th, td {
+    border: 1px solid #e5e5ea;
+    padding: 8px;
+    text-align: left;
+}
+th {
+    background-color: #f5f5f7;
+}
+"""
+
+    chapter_xhtml = f"""<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>{html.escape(title)}</title>
+    <link rel="stylesheet" type="text/css" href="stylesheet.css"/>
+</head>
+<body>
+    <div class="chapter">
+        {body_html}
+    </div>
+</body>
+</html>"""
+
+    content_opf = f"""<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookId" version="2.0">
+    <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+        <dc:title>{html.escape(title)}</dc:title>
+        <dc:creator opf:role="aut">{html.escape(author)}</dc:creator>
+        <dc:language>zh-CN</dc:language>
+        <dc:identifier id="BookId">{book_id}</dc:identifier>
+    </metadata>
+    <manifest>
+        <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>
+        <item id="style" href="stylesheet.css" media-type="text/css"/>
+        <item id="chapter1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine toc="ncx">
+        <itemref idref="chapter1"/>
+    </spine>
+</package>"""
+
+    toc_ncx = f"""<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ncx PUBLIC "-//NISO//DTD NCX 2005-1//EN" "http://www.daisy.org/z3986/2005/ncx-2005-1.dtd">
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+    <head>
+        <meta name="dtb:uid" content="{book_id}"/>
+        <meta name="dtb:depth" content="1"/>
+        <meta name="dtb:totalPageCount" content="0"/>
+        <meta name="dtb:maxPageNumber" content="0"/>
+    </head>
+    <docTitle>
+        <text>{html.escape(title)}</text>
+    </docTitle>
+    <navMap>
+        <navPoint id="navpoint-1" playOrder="1">
+            <navLabel>
+                <text>开始阅读</text>
+            </navLabel>
+            <content src="chapter1.xhtml"/>
+        </navPoint>
+    </navMap>
+</ncx>"""
+
+    # Ensure parent folder exists
+    parent_dir = os.path.dirname(output_path)
+    if parent_dir and not os.path.exists(parent_dir):
+        os.makedirs(parent_dir, exist_ok=True)
+
+    # Write out the epub zip package
+    # The 'mimetype' file must be written first and uncompressed (zipfile.ZIP_STORED)
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as epub:
+        # 1. mimetype (first and uncompressed)
+        epub.writestr("mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED)
+
+        # 2. META-INF/container.xml
+        epub.writestr("META-INF/container.xml", container_xml)
+
+        # 3. OEBPS contents
+        epub.writestr("OEBPS/content.opf", content_opf)
+        epub.writestr("OEBPS/toc.ncx", toc_ncx)
+        epub.writestr("OEBPS/stylesheet.css", stylesheet_css)
+        epub.writestr("OEBPS/chapter1.xhtml", chapter_xhtml)
+
+    logger.info(f"EPUB book successfully compiled & packed at {output_path}")
+    return output_path
+
+
+def _simple_md_to_html(md_text):
+    """Extremely lightweight and clean MD parser that produces strict XHTML compliant tags."""
+    import html
+    lines = md_text.split('\n')
+    xhtml_lines = []
+    in_list = False
+    in_code_block = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Code blocks
+        if stripped.startswith("```"):
+            if in_code_block:
+                xhtml_lines.append("</pre></code>")
+                in_code_block = False
+            else:
+                xhtml_lines.append("<pre><code>")
+                in_code_block = True
+            continue
+
+        if in_code_block:
+            xhtml_lines.append(html.escape(line))
+            continue
+
+        # Headings
+        heading_match = re.match(r'^(#{1,6})\s+(.*)$', stripped)
+        if heading_match:
+            if in_list:
+                xhtml_lines.append("</ul>")
+                in_list = False
+            level = len(heading_match.group(1))
+            content = heading_match.group(2)
+            xhtml_lines.append(f"<h{level}>{html.escape(content)}</h{level}>")
+            continue
+
+        # Lists
+        list_match = re.match(r'^[\-\*]\s+(.*)$', stripped)
+        if list_match:
+            if not in_list:
+                xhtml_lines.append("<ul>")
+                in_list = True
+            xhtml_lines.append(f"<li>{html.escape(list_match.group(1))}</li>")
+            continue
+        elif in_list and stripped == "":
+            xhtml_lines.append("</ul>")
+            in_list = False
+
+        # Tables
+        if stripped.startswith("|") and stripped.endswith("|"):
+            if in_list:
+                xhtml_lines.append("</ul>")
+                in_list = False
+            cells = [c.strip() for c in stripped.split("|")[1:-1]]
+            if len(cells) > 0:
+                if all(re.match(r'^:?-+:?$', c) for c in cells):
+                    continue
+                row_str = "".join(f"<td>{html.escape(c)}</td>" for c in cells)
+                xhtml_lines.append(f"<tr>{row_str}</tr>")
+            continue
+
+        # Normal Paragraphs
+        if stripped:
+            if in_list:
+                xhtml_lines.append("</ul>")
+                in_list = False
+            # Basic inline rendering (bold, italic)
+            line_html = html.escape(stripped)
+            line_html = re.sub(r'\*\*(.*?)\*\*', r'<strong>\1</strong>', line_html)
+            line_html = re.sub(r'\*(.*?)\*', r'<em>\1</em>', line_html)
+            line_html = re.sub(r'`(.*?)`', r'<code>\1</code>', line_html)
+            xhtml_lines.append(f"<p>{line_html}</p>")
+        else:
+            if in_list:
+                xhtml_lines.append("</ul>")
+                in_list = False
+
+    if in_list:
+        xhtml_lines.append("</ul>")
+
+    return "\n".join(xhtml_lines)

--- a/skills/format_convert/core/exporter_img.py
+++ b/skills/format_convert/core/exporter_img.py
@@ -1,0 +1,281 @@
+import os
+import re
+import logging
+
+logger = logging.getLogger("ImageExporter")
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+    PIL_AVAILABLE = True
+except ImportError:
+    PIL_AVAILABLE = False
+
+
+def markdown_to_image(md_text, output_path, opts=None):
+    """
+    Renders Markdown to a clean, elegant, long JPG/PNG image.
+    Uses pure-Python Pillow text-layout with automatic word wrap.
+    Excellent zero-dependency design with graceful fallback.
+    """
+    if not PIL_AVAILABLE:
+        logger.warning("Pillow library is not installed. Drawing basic mock visual representation.")
+        # Return a simple mock file or throw an error
+        raise ImportError("Pillow library is required for MD -> Image fallback. Please install pillow.")
+
+    opts = opts or {}
+    theme = opts.get("theme", "apple-light")
+    width = int(opts.get("width", 800))
+    padding = 50
+    line_spacing = 6
+    para_spacing = 15
+
+    # Aesthetic styles
+    if theme == "dark":
+        bg_color = (0x1C, 0x1C, 0x1E)
+        text_color = (0xEE, 0xEE, 0xEE)
+        h1_color = (0xFF, 0xFF, 0xFF)
+        h2_color = (0x0A, 0x84, 0xFF) # Vibrant Apple blue for dark theme headers
+        quote_bar_color = (0x30, 0xD1, 0x58) # Apple green
+        quote_bg_color = (0x2C, 0x2C, 0x2E)
+    else:
+        bg_color = (0xFF, 0xFF, 0xFF)
+        text_color = (0x1D, 0x1D, 0x1F)
+        h1_color = (0x1D, 0x1D, 0x1F)
+        h2_color = (0x00, 0x7A, 0xFF) # Signature Apple blue header accent
+        quote_bar_color = (0x00, 0x7A, 0xFF) # Signature Apple blue quote bar
+        quote_bg_color = (0xF4, 0xF4, 0xF4)
+
+    # 1. Font detection and sizing
+    font_path = ""
+    # Look for PingFang/Helvetica or fallbacks
+    fallbacks = [
+        "/System/Library/Fonts/PingFang.ttc",
+        "/Library/Fonts/Arial.ttf",
+        "C:\\Windows\\Fonts\\msyh.ttc",
+        "C:\\Windows\\Fonts\\msyh.ttf",
+        "C:\\Windows\\Fonts\\Arial.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+    ]
+    for p in fallbacks:
+        if os.path.exists(p):
+            font_path = p
+            break
+
+    # Load Pillow fonts
+    try:
+        if font_path:
+            f_title = ImageFont.truetype(font_path, 24)
+            f_header = ImageFont.truetype(font_path, 18)
+            f_body = ImageFont.truetype(font_path, 14)
+            f_quote = ImageFont.truetype(font_path, 13)
+        else:
+            f_title = f_header = f_body = f_quote = ImageFont.load_default()
+    except Exception as e:
+        logger.warning(f"Failed to load standard TTF font: {e}. Falling back to default layout.")
+        f_title = f_header = f_body = f_quote = ImageFont.load_default()
+
+    # 2. Text layout & wrap calculation
+    draw_width = width - 2 * padding
+    paragraphs = []
+    lines = md_text.split('\n')
+
+    # Parse and wrap blocks
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        if not stripped:
+            paragraphs.append({"type": "spacing", "height": 10})
+            i += 1
+            continue
+
+        # Headings
+        heading_match = re.match(r'^(#{1,6})\s+(.*)$', stripped)
+        if heading_match:
+            level = len(heading_match.group(1))
+            title_text = heading_match.group(2)
+            font_to_use = f_title if level == 1 else f_header
+            color_to_use = h1_color if level == 1 else h2_color
+
+            wrapped_lines = _wrap_text(title_text, font_to_use, draw_width)
+            paragraphs.append({
+                "type": "heading",
+                "level": level,
+                "lines": wrapped_lines,
+                "font": font_to_use,
+                "color": color_to_use
+            })
+            i += 1
+            continue
+
+        # Blockquotes
+        if stripped.startswith(">"):
+            quote_text = []
+            while i < len(lines) and lines[i].strip().startswith(">"):
+                quote_text.append(re.sub(r'^>\s*', '', lines[i].strip()))
+                i += 1
+            full_quote = " ".join(quote_text)
+            wrapped_lines = _wrap_text(full_quote, f_quote, draw_width - 30) # indentation
+            paragraphs.append({
+                "type": "blockquote",
+                "lines": wrapped_lines,
+                "font": f_quote,
+                "color": text_color
+            })
+            continue
+
+        # List items
+        list_match = re.match(r'^([\-\*\+])\s+(.*)$', stripped)
+        if list_match:
+            content = list_match.group(2)
+            # Indent content slightly
+            wrapped_lines = _wrap_text(content, f_body, draw_width - 25)
+            paragraphs.append({
+                "type": "list",
+                "bullet": "•",
+                "lines": wrapped_lines,
+                "font": f_body,
+                "color": text_color
+            })
+            i += 1
+            continue
+
+        # Normal Paragraph
+        wrapped_lines = _wrap_text(stripped, f_body, draw_width)
+        paragraphs.append({
+            "type": "paragraph",
+            "lines": wrapped_lines,
+            "font": f_body,
+            "color": text_color
+        })
+        i += 1
+
+    # 3. Compute dynamic height
+    curr_y = padding
+    for p in paragraphs:
+        if p["type"] == "spacing":
+            curr_y += p["height"]
+        elif p["type"] in ["paragraph", "heading", "list"]:
+            font_h = p["font"].getbbox("A")[3] if hasattr(p["font"], "getbbox") else 14
+            curr_y += len(p["lines"]) * (font_h + line_spacing) + para_spacing
+        elif p["type"] == "blockquote":
+            font_h = p["font"].getbbox("A")[3] if hasattr(p["font"], "getbbox") else 13
+            # blockquote has internal top/bottom padding of 8px
+            curr_y += len(p["lines"]) * (font_h + line_spacing) + 16 + para_spacing
+
+    total_height = curr_y + padding
+
+    # 4. Draw image
+    img = Image.new("RGB", (width, total_height), bg_color)
+    draw = ImageDraw.Draw(img)
+
+    curr_y = padding
+    for p in paragraphs:
+        if p["type"] == "spacing":
+            curr_y += p["height"]
+        elif p["type"] in ["paragraph", "heading"]:
+            font_h = p["font"].getbbox("A")[3] if hasattr(p["font"], "getbbox") else 14
+            for l_text in p["lines"]:
+                draw.text((padding, curr_y), l_text, font=p["font"], fill=p["color"])
+                curr_y += font_h + line_spacing
+            curr_y += para_spacing
+
+        elif p["type"] == "list":
+            font_h = p["font"].getbbox("A")[3] if hasattr(p["font"], "getbbox") else 14
+            # Draw bullet point
+            draw.text((padding, curr_y), p["bullet"], font=p["font"], fill=h2_color)
+            first = True
+            for l_text in p["lines"]:
+                indent_x = padding + 20
+                draw.text((indent_x, curr_y), l_text, font=p["font"], fill=p["color"])
+                curr_y += font_h + line_spacing
+            curr_y += para_spacing
+
+        elif p["type"] == "blockquote":
+            font_h = p["font"].getbbox("A")[3] if hasattr(p["font"], "getbbox") else 13
+            block_h = len(p["lines"]) * (font_h + line_spacing) + 12
+
+            # Draw Quote Background Box
+            draw.rectangle(
+                [(padding, curr_y), (width - padding, curr_y + block_h)],
+                fill=quote_bg_color
+            )
+            # Draw Thick Left Quote Border Line
+            draw.rectangle(
+                [(padding, curr_y), (padding + 4, curr_y + block_h)],
+                fill=quote_bar_color
+            )
+
+            quote_y = curr_y + 6
+            for l_text in p["lines"]:
+                draw.text((padding + 20, quote_y), l_text, font=p["font"], fill=p["color"])
+                quote_y += font_h + line_spacing
+
+            curr_y += block_h + para_spacing
+
+    # Save to path
+    parent_dir = os.path.dirname(output_path)
+    if parent_dir and not os.path.exists(parent_dir):
+        os.makedirs(parent_dir, exist_ok=True)
+    img.save(output_path, quality=90)
+    logger.info(f"Successfully drew elegant long-image at {output_path}")
+    return output_path
+
+
+def _wrap_text(text, font, max_width):
+    """Wraps text into multiple lines fitting inside max_width."""
+    words = text.split()
+    if not words:
+        return [text]
+
+    lines = []
+    curr_line = []
+
+    # Simple wrapping based on character count or pixel size
+    for word in words:
+        test_line = " ".join(curr_line + [word])
+        # Calculate width using getbbox or default character approximation
+        if hasattr(font, "getbbox"):
+            w = font.getbbox(test_line)[2]
+        else:
+            w = len(test_line) * 8
+
+        if w <= max_width:
+            curr_line.append(word)
+        else:
+            if curr_line:
+                lines.append(" ".join(curr_line))
+                curr_line = [word]
+            else:
+                # Single word too wide, force wrap
+                lines.append(word)
+                curr_line = []
+
+    if curr_line:
+        lines.append(" ".join(curr_line))
+
+    # Support double-byte CJK wrapping (split non-ASCII directly)
+    final_lines = []
+    for line in lines:
+        if any(ord(char) > 127 for char in line):
+            # Contains CJK characters, wrap strictly character by character
+            sub_line = ""
+            for char in line:
+                test_sub = sub_line + char
+                if hasattr(font, "getbbox"):
+                    sub_w = font.getbbox(test_sub)[2]
+                else:
+                    sub_w = len(test_sub) * 12
+                if sub_w <= max_width:
+                    sub_line += char
+                else:
+                    final_lines.append(sub_line)
+                    sub_line = char
+            if sub_line:
+                final_lines.append(sub_line)
+        else:
+            final_lines.append(line)
+
+    return final_lines

--- a/skills/format_convert/core/reverse_converters.py
+++ b/skills/format_convert/core/reverse_converters.py
@@ -1,0 +1,202 @@
+import re
+import os
+import logging
+
+logger = logging.getLogger("ReverseConverters")
+
+
+def _try_markitdown(file_path_or_bytes, suffix=".docx"):
+    """
+    Attempts to convert various formats to Markdown using:
+    1. Microsoft's official `markitdown` library
+    2. Butler's internal replica `skills.markitdown.markitdown_app`
+    Returns converted Markdown string or None.
+    """
+    # Create temp file if input is bytes
+    temp_path = None
+    if isinstance(file_path_or_bytes, bytes):
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp.write(file_path_or_bytes)
+            temp_path = tmp.name
+        file_path = temp_path
+    else:
+        file_path = file_path_or_bytes
+
+    try:
+        # Strategy A: Microsoft's official markitdown package
+        try:
+            from markitdown import MarkItDown
+            mid = MarkItDown()
+            result = mid.convert(file_path)
+            return result.text_content
+        except ImportError:
+            pass
+
+        # Strategy B: Butler's custom integrated markitdown_app replica
+        try:
+            # Add project root to path for absolute imports if needed
+            import sys
+            project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+            if project_root not in sys.path:
+                sys.path.insert(0, project_root)
+
+            from skills.markitdown.markitdown_app import convert as butler_convert
+            return butler_convert(file_path)
+        except Exception as e:
+            logger.info(f"Butler internal markitdown conversion skipped: {e}")
+
+    except Exception as e:
+        logger.warning(f"Markitdown strategy failed: {e}")
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            os.remove(temp_path)
+
+    return None
+
+
+def html_to_markdown(html_text):
+    """
+    Converts HTML back to clean Markdown format.
+    """
+    # Try markitdown first
+    mid_res = _try_markitdown(html_text.encode('utf-8'), suffix=".html")
+    if mid_res:
+        return mid_res
+
+    # Strategy C: markdownify
+    try:
+        from markdownify import markdownify as md
+        return md(html_text)
+    except ImportError:
+        logger.info("markdownify not installed. Running high-strength HTML to Markdown fallback regex parser.")
+
+        text = html_text
+
+        # Strip head, scripts, styling metadata
+        text = re.sub(r'<(style|script|head)\b[^>]*>([\s\S]*?)<\/\1>', '', text, flags=re.IGNORECASE)
+
+        # Headings mapping
+        text = re.sub(r'<h1\b[^>]*>(.*?)</h1>', r'# \1\n\n', text, flags=re.IGNORECASE)
+        text = re.sub(r'<h2\b[^>]*>(.*?)</h2>', r'## \1\n\n', text, flags=re.IGNORECASE)
+        text = re.sub(r'<h3\b[^>]*>(.*?)</h3>', r'### \1\n\n', text, flags=re.IGNORECASE)
+
+        # Lists mapping
+        text = re.sub(r'<li\b[^>]*>(.*?)</li>', r'- \1\n', text, flags=re.IGNORECASE)
+        text = re.sub(r'</?(ul|ol)>', r'\n', text, flags=re.IGNORECASE)
+
+        # Code blocks mapping
+        text = re.sub(r'<pre\b[^>]*><code\b[^>]*>([\s\S]*?)</code></pre>', r'```\n\1\n```\n\n', text, flags=re.IGNORECASE)
+        text = re.sub(r'<code\b[^>]*>(.*?)</code>', r'`\1`', text, flags=re.IGNORECASE)
+
+        # Bold & Italic mapping
+        text = re.sub(r'<(strong|b)\b[^>]*>(.*?)</\1>', r'**\2**', text, flags=re.IGNORECASE)
+        text = re.sub(r'<(em|i)\b[^>]*>(.*?)</\1>', r'*\2*', text, flags=re.IGNORECASE)
+
+        # Paragraphs & line breaks
+        text = re.sub(r'<p\b[^>]*>(.*?)</p>', r'\1\n\n', text, flags=re.IGNORECASE)
+        text = re.sub(r'<br\s*/?>', r'\n', text, flags=re.IGNORECASE)
+
+        # Strip remaining HTML tags
+        text = re.sub(r'<[^>]+>', '', text)
+
+        # Decode standard entities
+        text = text.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">").replace("&quot;", '"')
+
+        return text.strip()
+
+
+def docx_to_markdown(docx_path_or_bytes):
+    """
+    Parses a DOCX document back into structured Markdown notation.
+    """
+    # Try markitdown first
+    mid_res = _try_markitdown(docx_path_or_bytes, suffix=".docx")
+    if mid_res:
+        return mid_res
+
+    try:
+        from docx import Document
+    except ImportError:
+        raise ImportError("python-docx is required for reverse DOCX -> MD conversion.")
+
+    # Load from path or bytes stream
+    if isinstance(docx_path_or_bytes, bytes):
+        import io
+        doc = Document(io.BytesIO(docx_path_or_bytes))
+    else:
+        doc = Document(docx_path_or_bytes)
+
+    md_lines = []
+    for p in doc.paragraphs:
+        text = ""
+        # Inspect runs for inline formatting (bold, italic)
+        for run in p.runs:
+            r_text = run.text
+            if not r_text:
+                continue
+            if run.bold:
+                r_text = f"**{r_text}**"
+            if run.italic:
+                r_text = f"*{r_text}*"
+            text += r_text
+
+        # Check paragraph style / structure
+        style_name = p.style.name.lower()
+        if "heading 1" in style_name:
+            md_lines.append(f"# {text}\n")
+        elif "heading 2" in style_name:
+            md_lines.append(f"## {text}\n")
+        elif "heading 3" in style_name:
+            md_lines.append(f"### {text}\n")
+        elif "list bullet" in style_name or p.paragraph_format.left_indent:
+            md_lines.append(f"- {text}")
+        else:
+            if text.strip():
+                md_lines.append(text + "\n")
+
+    # Parse tables as markdown tables if present
+    for table in doc.tables:
+        table_md = []
+        for r_idx, row in enumerate(table.rows):
+            row_cells = [cell.text.replace("\n", " ").strip() for cell in row.cells]
+            table_md.append("| " + " | ".join(row_cells) + " |")
+            if r_idx == 0:
+                table_md.append("| " + " | ".join("---" for _ in row.cells) + " |")
+        md_lines.append("\n" + "\n".join(table_md) + "\n")
+
+    return "\n".join(md_lines).strip()
+
+
+def pdf_to_markdown(pdf_path_or_bytes):
+    """
+    Parses structural text from PDF pages and returns standard markdown string.
+    """
+    # Try markitdown first
+    mid_res = _try_markitdown(pdf_path_or_bytes, suffix=".pdf")
+    if mid_res:
+        return mid_res
+
+    # Try pypdf / pdfplumber
+    try:
+        from pypdf import PdfReader
+    except ImportError:
+        try:
+            from PyPDF2 import PdfReader
+        except ImportError:
+            raise ImportError("pypdf or PyPDF2 is required for reverse PDF -> MD conversion.")
+
+    import io
+    if isinstance(pdf_path_or_bytes, bytes):
+        reader = PdfReader(io.BytesIO(pdf_path_or_bytes))
+    else:
+        reader = PdfReader(pdf_path_or_bytes)
+
+    extracted_lines = []
+    for page in reader.pages:
+        txt = page.extract_text()
+        if txt:
+            extracted_lines.append(txt)
+
+    content = "\n\n".join(extracted_lines)
+    return content.strip()

--- a/skills/format_convert/format_convert.py
+++ b/skills/format_convert/format_convert.py
@@ -1,14 +1,24 @@
 import os
 import json
 import logging
+import base64
+import io
 from butler.core.runner_server import runner_server
 
+# Relative package imports
+from .core.exporter_docx import markdown_to_docx
+from .core.exporter_epub import markdown_to_epub
+from .core.exporter_img import markdown_to_image
+from .core.reverse_converters import html_to_markdown, docx_to_markdown, pdf_to_markdown
+
 logger = logging.getLogger("FormatConvertSkill")
+
 
 def handle_request(action, **kwargs):
     """
     Handle document format conversion requests.
     Supports action: "run" (and others if needed)
+    Supports both direct contents, URL downloads, and file paths.
     """
     entities = kwargs.get("entities", {})
 
@@ -39,11 +49,15 @@ def handle_request(action, **kwargs):
     if to_fmt in ["PNG"]: to_fmt = "PNG"
     if from_fmt in ["JPG", "JPEG"]: from_fmt = "JPG"
     if to_fmt in ["JPG", "JPEG"]: to_fmt = "JPG"
+    if from_fmt in ["DOCX", "WORD"]: from_fmt = "DOCX"
+    if to_fmt in ["DOCX", "WORD"]: to_fmt = "DOCX"
+    if from_fmt in ["EPUB", "EBOOK"]: from_fmt = "EPUB"
+    if to_fmt in ["EPUB", "EBOOK"]: to_fmt = "EPUB"
 
     # Options structure
     opts = {
-        "theme": options.get("theme", "default"),
-        "with_water": options.get("with_water", True),
+        "theme": options.get("theme", "apple-light"),
+        "with_water": options.get("with_water", False),
         "config": options.get("config", {})
     }
 
@@ -51,63 +65,174 @@ def handle_request(action, **kwargs):
     runners = runner_server.list_runners()
     if runners:
         runner_id = runners[0] # Pick the first available runner
-        logger.info(f"Delegating format conversion task to Go Runner: {runner_id}")
+        supported_go_paths = [
+            "MD->HTML", "JSON->CSV", "YAML->CSV", "CSV->XLSX", "JSON->XLSX",
+            "MD->PDF", "HTML->PDF", "JSON->MD", "CSV->MD", "PNG->WEBP", "JPG->WEBP"
+        ]
+        test_key = f"{from_fmt}->{to_fmt}"
+        if test_key in supported_go_paths:
+            logger.info(f"Delegating format conversion task to Go Runner: {runner_id}")
 
-        # Prepare WebSocket payload
-        task_payload = {
-            "input": input_val,
-            "from": from_fmt,
-            "to": to_fmt,
-            "save_to": save_to or "",
-            "options": opts
-        }
+            # Prepare WebSocket payload
+            task_payload = {
+                "input": input_val,
+                "from": from_fmt,
+                "to": to_fmt,
+                "save_to": save_to or "",
+                "options": opts
+            }
 
-        # Use send_command_sync to wait blockingly for the result
-        res = runner_server.send_command_sync(runner_id, "format_convert", json.dumps(task_payload))
-        if res.get("status") == "ok":
-            ret_data = res.get("data")
-            if save_to:
-                return f"Success: {ret_data}"
+            # Use send_command_sync to wait blockingly for the result
+            res = runner_server.send_command_sync(runner_id, "format_convert", json.dumps(task_payload))
+            if res.get("status") == "ok":
+                ret_data = res.get("data")
+                if save_to:
+                    return f"Success: {ret_data}"
+                else:
+                    return ret_data
             else:
-                return ret_data
-        else:
-            err_msg = res.get("error", "Unknown WebSocket conversion error")
-            logger.warning(f"Go Runner conversion failed: {err_msg}. Falling back to local python execution.")
+                err_msg = res.get("error", "Unknown WebSocket conversion error")
+                logger.warning(f"Go Runner conversion failed: {err_msg}. Falling back to local python execution.")
 
-    # 3. Local Fallback Execution (Pure Python)
+    # 3. Local Fallback Execution (Pure Python / Zero-Dependency Design)
     logger.info("Executing format conversion locally (Python Fallback)")
     try:
-        # Resolve source data as text for standard converters
+        # Resolve source data as bytes or string
+        src_is_file = False
+        src_bytes = b""
         src_content = ""
-        # WebP and Base64 converters will re-resolve input_val to binary if needed
-        if from_fmt not in ["PNG", "JPG"] and to_fmt not in ["WEBP", "BASE64"]:
-            if input_val.startswith("http://") or input_val.startswith("https://"):
-                import requests
-                resp = requests.get(input_val, timeout=10)
-                resp.raise_for_status()
-                src_content = resp.text
-            elif os.path.exists(input_val):
-                with open(input_val, 'r', encoding='utf-8') as f:
-                    src_content = f.read()
-            else:
-                src_content = input_val
-        else:
-            src_content = input_val
 
-        # Execute conversion logic based on path
+        # Check if the input is a file path on disk
+        if isinstance(input_val, str) and os.path.exists(input_val):
+            src_is_file = True
+            with open(input_val, 'rb') as f:
+                src_bytes = f.read()
+            try:
+                src_content = src_bytes.decode('utf-8')
+            except UnicodeDecodeError:
+                src_content = "" # Binary file
+        elif isinstance(input_val, str) and (input_val.startswith("http://") or input_val.startswith("https://")):
+            import requests
+            resp = requests.get(input_val, timeout=10)
+            resp.raise_for_status()
+            src_bytes = resp.content
+            try:
+                src_content = src_bytes.decode('utf-8')
+            except UnicodeDecodeError:
+                src_content = ""
+        else:
+            # Direct text input
+            if isinstance(input_val, str):
+                src_content = input_val
+                src_bytes = input_val.encode('utf-8')
+            elif isinstance(input_val, bytes):
+                src_bytes = input_val
+                try:
+                    src_content = input_val.decode('utf-8')
+                except UnicodeDecodeError:
+                    src_content = ""
+
+        # --- Reverse and Cross Conversion Pipeline ---
+        # Normalize non-MD sources by first converting them to MD intermediate representation
+        if from_fmt != "MD":
+            if from_fmt == "HTML":
+                src_content = html_to_markdown(src_content)
+            elif from_fmt == "DOCX":
+                source_input = input_val if (src_is_file and isinstance(input_val, str)) else src_bytes
+                src_content = docx_to_markdown(source_input)
+            elif from_fmt == "PDF":
+                source_input = input_val if (src_is_file and isinstance(input_val, str)) else src_bytes
+                src_content = pdf_to_markdown(source_input)
+            elif from_fmt in ["JSON", "YAML"] and to_fmt == "CSV":
+                # Supported directly below
+                pass
+            elif from_fmt in ["JSON", "CSV"] and to_fmt == "MD":
+                # Supported directly below
+                pass
+            else:
+                logger.info(f"Format {from_fmt} converted to intermediate Markdown before exporting.")
+
+            # Route to MD if target requires standard export, otherwise maintain for specialized handlers
+            if from_fmt in ["PNG", "JPG"] and to_fmt in ["WEBP", "BASE64"]:
+                pass
+            elif from_fmt in ["JSON", "YAML", "CSV"] and to_fmt in ["CSV", "MD", "XLSX"]:
+                pass
+            else:
+                from_fmt = "MD"
+
+        # Execute target conversion logic
         result = ""
         if from_fmt == "MD" and to_fmt == "HTML":
             result = local_md_to_html(src_content, opts)
+        elif from_fmt == "MD" and to_fmt == "DOCX":
+            if save_to:
+                result = markdown_to_docx(src_content, save_to, opts)
+                return f"Success: Saved to {save_to}"
+            else:
+                import tempfile
+                with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as tmp:
+                    tmp_path = tmp.name
+                try:
+                    markdown_to_docx(src_content, tmp_path, opts)
+                    with open(tmp_path, 'rb') as f:
+                        result = f.read()
+                finally:
+                    if os.path.exists(tmp_path):
+                        os.remove(tmp_path)
+
+        elif from_fmt == "MD" and to_fmt == "EPUB":
+            if save_to:
+                result = markdown_to_epub(src_content, save_to, opts)
+                return f"Success: Saved to {save_to}"
+            else:
+                import tempfile
+                with tempfile.NamedTemporaryFile(suffix=".epub", delete=False) as tmp:
+                    tmp_path = tmp.name
+                try:
+                    markdown_to_epub(src_content, tmp_path, opts)
+                    with open(tmp_path, 'rb') as f:
+                        result = f.read()
+                finally:
+                    if os.path.exists(tmp_path):
+                        os.remove(tmp_path)
+
+        elif from_fmt == "MD" and to_fmt in ["PNG", "JPG"]:
+            if save_to:
+                result = markdown_to_image(src_content, save_to, opts)
+                return f"Success: Saved to {save_to}"
+            else:
+                import tempfile
+                with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+                    tmp_path = tmp.name
+                try:
+                    markdown_to_image(src_content, tmp_path, opts)
+                    with open(tmp_path, 'rb') as f:
+                        result = f.read()
+                finally:
+                    if os.path.exists(tmp_path):
+                        os.remove(tmp_path)
+
         elif from_fmt in ["JSON", "YAML"] and to_fmt == "CSV":
             result = local_data_to_csv(src_content, from_fmt, opts)
         elif to_fmt == "XLSX":
             result = _local_fallback_xlsx(src_content, from_fmt, opts)
         elif to_fmt == "MD":
-            result = _local_fallback_md(src_content, from_fmt, opts)
+            if from_fmt == "MD":
+                result = src_content
+            else:
+                result = _local_fallback_md(src_content, from_fmt, opts)
         elif to_fmt in ["WEBP", "BASE64"] or from_fmt in ["PNG", "JPG"]:
             result = _local_fallback_image(src_content, from_fmt, to_fmt, opts)
         elif to_fmt == "PDF":
             result = _local_fallback_pdf(src_content, from_fmt, opts)
+            if not isinstance(result, bytes) and save_to:
+                with open(save_to, 'w', encoding='utf-8') as f:
+                    f.write(result)
+                return f"Success: Saved to {save_to}"
+            elif isinstance(result, bytes) and save_to:
+                with open(save_to, 'wb') as f:
+                    f.write(result)
+                return f"Success: Saved to {save_to}"
         else:
             return f"Error: Unsupported local conversion path: {from_fmt} -> {to_fmt}"
 
@@ -125,7 +250,6 @@ def handle_request(action, **kwargs):
             return f"Success: Saved to {save_to}"
         else:
             if isinstance(result, bytes):
-                import base64
                 return base64.b64encode(result).decode('utf-8')
             return result
 
@@ -137,8 +261,8 @@ def handle_request(action, **kwargs):
 def local_md_to_html(md_text, opts):
     """Simple pure Python Markdown to HTML parser for zero-dependency local fallback."""
     import re
-    theme = opts.get("theme", "default")
-    with_water = opts.get("with_water", True)
+    theme = opts.get("theme", "apple-light")
+    with_water = opts.get("with_water", False)
 
     lines = md_text.split('\n')
     html_lines = []
@@ -159,7 +283,6 @@ def local_md_to_html(md_text, opts):
             continue
 
         if in_code_block:
-            # Escape HTML characters in code block
             escaped = line.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
             html_lines.append(escaped)
             continue
@@ -179,7 +302,7 @@ def local_md_to_html(md_text, opts):
         list_match = re.match(r'^[\-\*]\s+(.*)$', stripped)
         if list_match:
             if not in_list:
-                html_lines.append("</ul>")
+                html_lines.append("<ul>")
                 in_list = True
             html_lines.append(f"<li>{list_match.group(1)}</li>")
             continue
@@ -194,7 +317,6 @@ def local_md_to_html(md_text, opts):
                 in_list = False
             cells = [c.strip() for c in stripped.split("|")[1:-1]]
             if len(cells) > 0:
-                # If separator line, ignore
                 if all(re.match(r'^:?-+:?$', c) for c in cells):
                     continue
                 row_str = "".join(f"<td>{c}</td>" for c in cells)
@@ -206,7 +328,6 @@ def local_md_to_html(md_text, opts):
             if in_list:
                 html_lines.append("</ul>")
                 in_list = False
-            # Simple Inline replacement
             line_html = stripped
             line_html = re.sub(r'\*\*(.*?)\*\*', r'<strong>\1</strong>', line_html)
             line_html = re.sub(r'\*(.*?)\*', r'<em>\1</em>', line_html)
@@ -335,8 +456,56 @@ def _local_fallback_xlsx(src_content, from_fmt, opts):
 
 
 def _local_fallback_pdf(src_content, from_fmt, opts):
-    """Local fallback for PDF: PDF formatting is not locally supported, raise exception."""
-    raise ValueError("Local fallback for PDF is not supported. Please connect a Go Runner.")
+    """Local fallback for PDF: Try using reportlab flowable layouting; otherwise fall back."""
+    try:
+        from reportlab.lib.pagesizes import letter
+        from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer
+        from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+        from reportlab.lib.enums import TA_CENTER
+
+        pdf_buffer = io.BytesIO()
+        doc = SimpleDocTemplate(pdf_buffer, pagesize=letter)
+        styles = getSampleStyleSheet()
+
+        # Build clean custom styles
+        title_style = ParagraphStyle(
+            'ApplePDFTitle',
+            parent=styles['Heading1'],
+            fontSize=22,
+            leading=26,
+            textColor='#1D1D1F',
+            spaceAfter=15
+        )
+        body_style = ParagraphStyle(
+            'ApplePDFBody',
+            parent=styles['Normal'],
+            fontSize=11,
+            leading=15,
+            textColor='#333333',
+            spaceAfter=8
+        )
+
+        story = []
+        for line in src_content.split('\n'):
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("# "):
+                story.append(Paragraph(line[2:], title_style))
+                story.append(Spacer(1, 10))
+            elif line.startswith("## "):
+                story.append(Paragraph(line[3:], styles['Heading2']))
+                story.append(Spacer(1, 8))
+            else:
+                story.append(Paragraph(line, body_style))
+                story.append(Spacer(1, 6))
+
+        doc.build(story)
+        return pdf_buffer.getvalue()
+
+    except Exception as e:
+        logger.warning(f"ReportLab PDF generation fallback skipped or failed: {e}. Raising standard exception.")
+        raise ValueError("Local fallback for PDF is not supported. Please connect a Go Runner.")
 
 
 def _local_fallback_md(src_content, from_fmt, opts):
@@ -344,7 +513,6 @@ def _local_fallback_md(src_content, from_fmt, opts):
     import csv
     import io
 
-    # 1. Resolve to standard rows
     rows = []
     if from_fmt == "JSON":
         data = json.loads(src_content)
@@ -386,7 +554,7 @@ def _local_fallback_md(src_content, from_fmt, opts):
         val_str = val_str.replace("\r\n", "<br />").replace("\n", "<br />")
         return val_str
 
-    # 2. Render Table
+    # Render Table
     md_lines = []
     md_lines.append("| " + " | ".join(escape_cell(h) for h in headers) + " |")
     md_lines.append("| " + " | ".join("---" for _ in headers) + " |")
@@ -398,7 +566,6 @@ def _local_fallback_md(src_content, from_fmt, opts):
 
 def _local_fallback_image(src_content, from_fmt, to_fmt, opts):
     """Converts image to WebP or Base64 in pure Python."""
-    import base64
     import io
 
     binary_data = b""

--- a/skills/format_convert/run.py
+++ b/skills/format_convert/run.py
@@ -1,0 +1,130 @@
+import os
+import sys
+import logging
+import webbrowser
+from pathlib import Path
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger("DocumentStudio")
+
+# Add project root to path for correct importing
+project_root = Path(__file__).resolve().parent.parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+try:
+    from flask import Flask, request, jsonify, render_template_string
+    FLASK_AVAILABLE = True
+except ImportError:
+    FLASK_AVAILABLE = False
+
+
+def check_and_install_dependencies():
+    """Checks and reports missing optional document conversion packages."""
+    missing = []
+    try:
+        import docx
+    except ImportError:
+        missing.append("python-docx")
+    try:
+        import PIL
+    except ImportError:
+        missing.append("pillow")
+    try:
+        import reportlab
+    except ImportError:
+        missing.append("reportlab")
+
+    if missing:
+        logger.info("=" * 60)
+        logger.info("💡 提示: 检测到以下可选转换库尚未安装。若需完整功能，建议安装:")
+        logger.info(f"   pip install {' '.join(missing)}")
+        logger.info("=" * 60)
+    else:
+        logger.info("✅ 所有的文档格式转换底层核心依赖检测已全部通过！")
+
+
+def create_app():
+    if not FLASK_AVAILABLE:
+        # Emergency simple server using http.server if Flask is missing
+        logger.warning("Flask is not installed in the environment. Standalone mode cannot run Flask webserver.")
+        return None
+
+    app = Flask(__name__)
+
+    # Load the gorgeous template content
+    template_path = Path(__file__).resolve().parent / "templates" / "export_ui.html"
+    if template_path.exists():
+        with open(template_path, 'r', encoding='utf-8') as f:
+            template_content = f.read()
+    else:
+        template_content = "<h1>Butler Document Studio Template Not Found</h1>"
+
+    @app.route("/")
+    def index():
+        return render_template_string(template_content)
+
+    @app.route("/api/convert", methods=["POST"])
+    def convert_api():
+        from skills.format_convert.format_convert import handle_request
+        try:
+            data = request.json or {}
+            input_val = data.get("input")
+            from_fmt = data.get("from", "MD")
+            to_fmt = data.get("to")
+            options = data.get("options", {})
+
+            if not input_val or not to_fmt:
+                return jsonify({"status": "error", "error": "Missing parameters 'input' or 'to'"}), 400
+
+            # Execute format conversion using handle_request with unpacked keyword arguments
+            # to avoid Python keyword collision on "from"
+            kwargs = {
+                "input": input_val,
+                "from": from_fmt,
+                "to": to_fmt,
+                "options": options
+            }
+            res = handle_request(action="run", **kwargs)
+
+            if isinstance(res, str) and res.startswith("Error:"):
+                return jsonify({"status": "error", "error": res})
+
+            return jsonify({
+                "status": "ok",
+                "base64": res
+            })
+
+        except Exception as e:
+            logger.error(f"API conversion failed: {e}", exc_info=True)
+            return jsonify({"status": "error", "error": str(e)}), 500
+
+    return app
+
+
+def main():
+    check_and_install_dependencies()
+
+    app = create_app()
+    if not app:
+        logger.error("无法启动本地 Web 服务：缺少 Flask。请通过 pip install flask 安装。")
+        sys.exit(1)
+
+    port = 8011
+    url = f"http://127.0.0.1:{port}"
+    logger.info(f"🚀 Butler Document Studio (极简文档工作室) 正在启动...")
+    logger.info(f"🔗 本地 Web 预览页面地址: {url}")
+
+    # Auto open browser
+    try:
+        webbrowser.open(url)
+    except Exception as e:
+        logger.warning(f"无法自动打开浏览器: {e}")
+
+    # Run Flask app (host on 127.0.0.1 for local isolation and security)
+    app.run(host="127.0.0.1", port=port, debug=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/format_convert/templates/export_ui.html
+++ b/skills/format_convert/templates/export_ui.html
@@ -1,0 +1,710 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Butler Document Studio | 极简文档工作室</title>
+    <style>
+        :root {
+            --primary-color: #007aff;
+            --primary-hover: #0063cc;
+            --bg-glass: rgba(255, 255, 255, 0.7);
+            --bg-glass-dark: rgba(30, 30, 30, 0.75);
+            --border-glass: rgba(255, 255, 255, 0.3);
+            --border-glass-dark: rgba(255, 255, 255, 0.1);
+            --shadow-glass: 0 8px 32px 0 rgba(0, 0, 0, 0.08);
+            --text-color: #1d1d1f;
+            --text-muted: #8e8e93;
+            --bg-page: #f5f5f7;
+            --transition-speed: 0.3s;
+        }
+
+        [data-theme="dark"] {
+            --text-color: #f5f5f7;
+            --text-muted: #8e8e93;
+            --bg-page: #000000;
+            --bg-glass: var(--bg-glass-dark);
+            --border-glass: var(--border-glass-dark);
+            --shadow-glass: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "PingFang SC", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background-color: var(--bg-page);
+            color: var(--text-color);
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            transition: background-color var(--transition-speed), color var(--transition-speed);
+            overflow-x: hidden;
+        }
+
+        /* Ambient colored background blobs for Apple glassmorphic effect */
+        .ambient-glow-1 {
+            position: fixed;
+            top: -200px;
+            left: -200px;
+            width: 600px;
+            height: 600px;
+            background: radial-gradient(circle, rgba(0, 122, 255, 0.15) 0%, rgba(255, 255, 255, 0) 70%);
+            z-index: -1;
+            pointer-events: none;
+        }
+
+        .ambient-glow-2 {
+            position: fixed;
+            bottom: -150px;
+            right: -150px;
+            width: 500px;
+            height: 500px;
+            background: radial-gradient(circle, rgba(58, 203, 114, 0.12) 0%, rgba(255, 255, 255, 0) 70%);
+            z-index: -1;
+            pointer-events: none;
+        }
+
+        header {
+            background: var(--bg-glass);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            border-bottom: 1px solid var(--border-glass);
+            padding: 1rem 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+
+        .brand {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .brand-icon {
+            font-size: 1.8rem;
+        }
+
+        .brand-text h1 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            letter-spacing: -0.02em;
+        }
+
+        .brand-text p {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+        }
+
+        .header-actions {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .btn-icon {
+            background: transparent;
+            border: none;
+            color: var(--text-color);
+            cursor: pointer;
+            font-size: 1.25rem;
+            padding: 8px;
+            border-radius: 50%;
+            transition: background var(--transition-speed);
+        }
+
+        .btn-icon:hover {
+            background: rgba(0, 0, 0, 0.05);
+        }
+
+        [data-theme="dark"] .btn-icon:hover {
+            background: rgba(255, 255, 255, 0.08);
+        }
+
+        main {
+            flex: 1;
+            max-width: 1400px;
+            width: 100%;
+            margin: 2rem auto;
+            padding: 0 1.5rem;
+            display: grid;
+            grid-template-columns: 1.1fr 0.9fr;
+            gap: 2rem;
+        }
+
+        @media (max-width: 900px) {
+            main {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .workspace-panel {
+            background: var(--bg-glass);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            border: 1px solid var(--border-glass);
+            border-radius: 20px;
+            box-shadow: var(--shadow-glass);
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+            height: 75vh;
+        }
+
+        .panel-header {
+            padding: 1rem 1.5rem;
+            border-bottom: 1px solid var(--border-glass);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .panel-title {
+            font-size: 0.95rem;
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .workspace-tabs {
+            display: flex;
+            gap: 4px;
+            background: rgba(0, 0, 0, 0.03);
+            padding: 3px;
+            border-radius: 8px;
+        }
+
+        [data-theme="dark"] .workspace-tabs {
+            background: rgba(255, 255, 255, 0.03);
+        }
+
+        .tab-btn {
+            background: transparent;
+            border: none;
+            color: var(--text-muted);
+            font-weight: 500;
+            font-size: 0.8rem;
+            padding: 6px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .tab-btn.active {
+            background: #ffffff;
+            color: var(--primary-color);
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+        }
+
+        [data-theme="dark"] .tab-btn.active {
+            background: rgba(255, 255, 255, 0.1);
+            color: #ffffff;
+        }
+
+        .panel-body {
+            flex: 1;
+            position: relative;
+            display: flex;
+            flex-direction: column;
+        }
+
+        textarea {
+            width: 100%;
+            height: 100%;
+            border: none;
+            background: transparent;
+            resize: none;
+            outline: none;
+            padding: 1.5rem;
+            font-family: "SFMono-Regular", Consolas, Menlo, monospace;
+            font-size: 0.9rem;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .preview-container {
+            width: 100%;
+            height: 100%;
+            padding: 1.5rem;
+            overflow-y: auto;
+            background: rgba(255, 255, 255, 0.15);
+        }
+
+        [data-theme="dark"] .preview-container {
+            background: rgba(0, 0, 0, 0.1);
+        }
+
+        .format-selector {
+            padding: 1.5rem;
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 12px;
+        }
+
+        .format-card {
+            background: rgba(255, 255, 255, 0.4);
+            border: 1px solid var(--border-glass);
+            border-radius: 12px;
+            padding: 1rem 0.5rem;
+            text-align: center;
+            cursor: pointer;
+            transition: all var(--transition-speed);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 8px;
+        }
+
+        [data-theme="dark"] .format-card {
+            background: rgba(255, 255, 255, 0.03);
+        }
+
+        .format-card:hover {
+            transform: translateY(-2px);
+            border-color: var(--primary-color);
+            background: #ffffff;
+            box-shadow: 0 4px 12px rgba(0, 122, 255, 0.1);
+        }
+
+        [data-theme="dark"] .format-card:hover {
+            background: rgba(255, 255, 255, 0.08);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+        }
+
+        .format-card.active {
+            border-color: var(--primary-color);
+            background: rgba(0, 122, 255, 0.08);
+            color: var(--primary-color);
+            font-weight: 600;
+        }
+
+        .format-icon {
+            font-size: 1.6rem;
+        }
+
+        .format-name {
+            font-size: 0.8rem;
+        }
+
+        .settings-grid {
+            padding: 1.5rem;
+            border-top: 1px solid var(--border-glass);
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 1rem;
+        }
+
+        .form-group {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .form-label {
+            font-size: 0.75rem;
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+        }
+
+        .form-input {
+            background: rgba(0, 0, 0, 0.03);
+            border: 1px solid var(--border-glass);
+            border-radius: 8px;
+            padding: 8px 12px;
+            font-size: 0.85rem;
+            color: var(--text-color);
+            outline: none;
+            transition: border-color 0.2s;
+        }
+
+        [data-theme="dark"] .form-input {
+            background: rgba(255, 255, 255, 0.05);
+        }
+
+        .form-input:focus {
+            border-color: var(--primary-color);
+        }
+
+        .btn-primary {
+            background: var(--primary-color);
+            color: #ffffff;
+            border: none;
+            border-radius: 12px;
+            padding: 12px 24px;
+            font-size: 0.95rem;
+            font-weight: 600;
+            cursor: pointer;
+            width: calc(100% - 3rem);
+            margin: 0 1.5rem 1.5rem 1.5rem;
+            transition: all 0.2s;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .btn-primary:hover {
+            background: var(--primary-hover);
+            transform: translateY(-1px);
+        }
+
+        /* Floating action notifications */
+        .toast {
+            position: fixed;
+            bottom: 2rem;
+            right: 2rem;
+            background: var(--bg-glass);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            border: 1px solid var(--border-glass);
+            padding: 1rem 1.5rem;
+            border-radius: 12px;
+            box-shadow: var(--shadow-glass);
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            transform: translateY(150px);
+            transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+            z-index: 1000;
+        }
+
+        .toast.show {
+            transform: translateY(0);
+        }
+
+        /* Mini document stylesheet preview mockup */
+        .preview-html h1 { font-size: 1.6em; margin-bottom: 0.8em; }
+        .preview-html h2 { font-size: 1.3em; margin: 1em 0 0.5em 0; border-bottom: 1px solid rgba(0,0,0,0.08); padding-bottom: 0.2em; }
+        .preview-html p { margin-bottom: 0.8em; line-height: 1.5; font-size: 0.95rem; }
+        .preview-html blockquote { border-left: 3px solid var(--primary-color); padding-left: 10px; color: var(--text-muted); margin: 1em 0; font-style: italic; background: rgba(0,0,0,0.02); }
+        .preview-html pre { background: rgba(0,0,0,0.04); padding: 10px; border-radius: 6px; font-family: monospace; overflow-x: auto; margin-bottom: 1em; }
+        .preview-html table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+        .preview-html th, .preview-html td { border: 1px solid rgba(0,0,0,0.08); padding: 6px 10px; font-size: 0.85rem; }
+        .preview-html th { background: rgba(0,0,0,0.04); }
+
+        @media print {
+            header, .workspace-panel:first-child, .workspace-panel:last-child .format-selector, .workspace-panel:last-child .settings-grid, .workspace-panel:last-child .btn-primary, .workspace-panel:last-child .panel-header, .ambient-glow-1, .ambient-glow-2 {
+                display: none !important;
+            }
+            body, .workspace-panel:last-child {
+                background: white !important;
+                color: black !important;
+                box-shadow: none !important;
+                border: none !important;
+                height: auto !important;
+            }
+            .preview-container {
+                background: white !important;
+                overflow: visible !important;
+                padding: 0 !important;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="ambient-glow-1"></div>
+    <div class="ambient-glow-2"></div>
+
+    <header>
+        <div class="brand">
+            <span class="brand-icon">📚</span>
+            <div class="brand-text">
+                <h1>Butler Document Studio</h1>
+                <p>智能文档跨格式导出中心 (AI & Manual Dual-Mode)</p>
+            </div>
+        </div>
+        <div class="header-actions">
+            <button class="btn-icon" id="theme-toggle" title="切换主题">🌓</button>
+        </div>
+    </header>
+
+    <main>
+        <!-- Left panel: Markdown Editor -->
+        <section class="workspace-panel">
+            <div class="panel-header">
+                <span class="panel-title">Markdown 编辑器</span>
+                <div class="workspace-tabs">
+                    <button class="tab-btn active" id="btn-edit">编辑</button>
+                    <button class="tab-btn" id="btn-preview">实时预览</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <textarea id="markdown-input" placeholder="在此粘贴或编写您的 Markdown 文档...
+
+# 极简设计
+支持多种格式的精美导出。
+
+- ⚡️ 一键导出 Word (.docx)
+- 📚 零依赖 EPUB 电子书打包
+- 🎨 精美长图生成
+- 📄 高清无损 PDF 导出
+
+## 引用示例
+> 极简不是缺乏，而是精髓的提炼。
+" style="display: block;"></textarea>
+                <div class="preview-container preview-html" id="html-preview" style="display: none;"></div>
+            </div>
+        </section>
+
+        <!-- Right panel: Export & Cross-Conversion Controls -->
+        <section class="workspace-panel" style="height: auto;">
+            <div class="panel-header">
+                <span class="panel-title">导出与交转换面板</span>
+            </div>
+
+            <!-- Format Selector -->
+            <div class="format-selector">
+                <div class="format-card active" data-format="HTML">
+                    <span class="format-icon">🌐</span>
+                    <span class="format-name">HTML</span>
+                </div>
+                <div class="format-card" data-format="DOCX">
+                    <span class="format-icon">📄</span>
+                    <span class="format-name">Word (.docx)</span>
+                </div>
+                <div class="format-card" data-format="EPUB">
+                    <span class="format-icon">📚</span>
+                    <span class="format-name">EPUB 电子书</span>
+                </div>
+                <div class="format-card" data-format="PNG">
+                    <span class="format-icon">🖼️</span>
+                    <span class="format-name">PNG 长图</span>
+                </div>
+            </div>
+
+            <!-- Parameter settings -->
+            <div class="settings-grid">
+                <div class="form-group">
+                    <label class="form-label">文档标题</label>
+                    <input type="text" id="doc-title" class="form-input" value="未命名文档">
+                </div>
+                <div class="form-group">
+                    <label class="form-label">作者/出品</label>
+                    <input type="text" id="doc-author" class="form-input" value="Butler Autopilot">
+                </div>
+                <div class="form-group">
+                    <label class="form-label">视觉风格</label>
+                    <select id="doc-theme" class="form-input" style="background: var(--bg-page); border: 1px solid var(--border-glass);">
+                        <option value="apple-light">Apple Light 极简</option>
+                        <option value="dark">Cyberpunk Dark</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">附加水印</label>
+                    <select id="doc-water" class="form-input" style="background: var(--bg-page); border: 1px solid var(--border-glass);">
+                        <option value="true">开启安全水印</option>
+                        <option value="false">无水印</option>
+                    </select>
+                </div>
+            </div>
+
+            <button class="btn-primary" id="btn-export">
+                <span>⚡️ 一键编译并导出</span>
+            </button>
+
+            <!-- PDF special print button (Zero-dependency web integration) -->
+            <button class="btn-primary" id="btn-print-pdf" style="background: #34c759; margin-top: -10px;">
+                <span>🖨️ 浏览器无损打印 PDF</span>
+            </button>
+        </section>
+    </main>
+
+    <div class="toast" id="notification">
+        <span id="toast-icon">✨</span>
+        <span id="toast-msg">转换就绪</span>
+    </div>
+
+    <script>
+        // Interactive script with visual controls
+        const themeBtn = document.getElementById('theme-toggle');
+        const inputArea = document.getElementById('markdown-input');
+        const previewContainer = document.getElementById('html-preview');
+        const btnEdit = document.getElementById('btn-edit');
+        const btnPreview = document.getElementById('btn-preview');
+        const formatCards = document.querySelectorAll('.format-card');
+        const btnExport = document.getElementById('btn-export');
+        const btnPrintPdf = document.getElementById('btn-print-pdf');
+        const toast = document.getElementById('notification');
+        const toastMsg = document.getElementById('toast-msg');
+
+        let selectedFormat = 'HTML';
+
+        // Theme management
+        themeBtn.addEventListener('click', () => {
+            const currentTheme = document.documentElement.getAttribute('data-theme');
+            const targetTheme = currentTheme === 'dark' ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-theme', targetTheme);
+            showToast('🌓 主题已切换');
+        });
+
+        // Tabs management
+        btnEdit.addEventListener('click', () => {
+            btnEdit.classList.add('active');
+            btnPreview.classList.remove('active');
+            inputArea.style.display = 'block';
+            previewContainer.style.display = 'none';
+        });
+
+        btnPreview.addEventListener('click', () => {
+            btnPreview.classList.add('active');
+            btnEdit.classList.remove('active');
+            inputArea.style.display = 'none';
+            previewContainer.style.display = 'block';
+            renderPreview();
+        });
+
+        // Format selection
+        formatCards.forEach(card => {
+            card.addEventListener('click', () => {
+                formatCards.forEach(c => c.classList.remove('active'));
+                card.classList.add('active');
+                selectedFormat = card.getAttribute('data-format');
+                showToast(`🎯 已选择导出格式: ${selectedFormat}`);
+            });
+        });
+
+        // HTML instant preview renderer (minimal parser)
+        function renderPreview() {
+            const md = inputArea.value;
+            // Simple visual parsing mapping for inline styling
+            let lines = md.split('\n');
+            let html = '';
+            let inList = false;
+
+            lines.forEach(line => {
+                let s = line.trim();
+                if (!s) {
+                    if (inList) { html += '</ul>'; inList = false; }
+                    return;
+                }
+                if (s.startsWith('# ')) {
+                    if (inList) { html += '</ul>'; inList = false; }
+                    html += `<h1>${s.substring(2)}</h1>`;
+                } else if (s.startsWith('## ')) {
+                    if (inList) { html += '</ul>'; inList = false; }
+                    html += `<h2>${s.substring(3)}</h2>`;
+                } else if (s.startsWith('- ')) {
+                    if (!inList) { html += '<ul>'; inList = true; }
+                    html += `<li>${s.substring(2)}</li>`;
+                } else if (s.startsWith('> ')) {
+                    if (inList) { html += '</ul>'; inList = false; }
+                    html += `<blockquote>${s.substring(2)}</blockquote>`;
+                } else {
+                    if (inList) { html += '</ul>'; inList = false; }
+                    // inline replace bold/italic
+                    let formatted = s
+                        .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+                        .replace(/\*(.*?)\*/g, '<em>$1</em>')
+                        .replace(/`(.*?)`/g, '<code>$1</code>');
+                    html += `<p>${formatted}</p>`;
+                }
+            });
+            if (inList) html += '</ul>';
+            previewContainer.innerHTML = html;
+        }
+
+        // Export handler via fetch API
+        btnExport.addEventListener('click', async () => {
+            const title = document.getElementById('doc-title').value;
+            const author = document.getElementById('doc-author').value;
+            const theme = document.getElementById('doc-theme').value;
+            const withWater = document.getElementById('doc-water').value === 'true';
+            const mdContent = inputArea.value;
+
+            showToast('🔄 正在打包并编译您的文档...');
+
+            try {
+                const response = await fetch('/api/convert', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        input: mdContent,
+                        from: 'MD',
+                        to: selectedFormat,
+                        options: {
+                            theme: theme,
+                            with_water: withWater,
+                            config: {
+                                title: title,
+                                author: author
+                            }
+                        }
+                    })
+                });
+
+                if (!response.ok) throw new Error('网络请求错误');
+                const data = await response.json();
+
+                if (data.status === 'ok') {
+                    showToast('🎉 文档完美导出成功！');
+                    // Trigger dynamic blob download
+                    const blob = b64ToBlob(data.base64, getMimeType(selectedFormat));
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = `${title}.${selectedFormat.toLowerCase()}`;
+                    document.body.appendChild(a);
+                    a.click();
+                    document.body.removeChild(a);
+                } else {
+                    showToast(`❌ 导出失败: ${data.error || '未知错误'}`);
+                }
+            } catch (err) {
+                showToast(`❌ 导出异常: ${err.message}`);
+            }
+        });
+
+        // PDF Web-Print integration
+        btnPrintPdf.addEventListener('click', () => {
+            btnPreview.click(); // ensure preview tab is rendering
+            setTimeout(() => {
+                window.print();
+            }, 300);
+        });
+
+        function showToast(msg) {
+            toastMsg.innerText = msg;
+            toast.classList.add('show');
+            setTimeout(() => {
+                toast.classList.remove('show');
+            }, 3000);
+        }
+
+        function b64ToBlob(b64Data, contentType='', sliceSize=512) {
+            const byteCharacters = atob(b64Data);
+            const byteArrays = [];
+            for (let offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+                const slice = byteCharacters.slice(offset, offset + sliceSize);
+                const byteNumbers = new Array(slice.length);
+                for (let i = 0; i < slice.length; i++) {
+                    byteNumbers[i] = slice.charCodeAt(i);
+                }
+                const byteArray = new Uint8Array(byteNumbers);
+                byteArrays.push(byteArray);
+            }
+            return new Blob(byteArrays, {type: contentType});
+        }
+
+        function getMimeType(fmt) {
+            switch(fmt) {
+                case 'HTML': return 'text/html';
+                case 'DOCX': return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+                case 'EPUB': return 'application/epub+zip';
+                case 'PNG': return 'image/png';
+                default: return 'application/octet-stream';
+            }
+        }
+    </script>
+</body>
+</html>

--- a/verification/test_format_convert.py
+++ b/verification/test_format_convert.py
@@ -3,13 +3,16 @@ import sys
 import unittest
 import base64
 import io
+import tempfile
+import zipfile
 
 # Ensure project root is in path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from skills.format_convert.main import handle_request
+from skills.format_convert.format_convert import handle_request
+from skills.format_convert.core.reverse_converters import html_to_markdown, docx_to_markdown, pdf_to_markdown
 
 
 class TestFormatConvertSkillLocal(unittest.TestCase):
@@ -170,15 +173,114 @@ This is **important** text."""
         except ImportError:
             self.skipTest("Pillow not installed, skipping test_image_to_webp_local")
 
-    def test_pdf_local_fallback_error(self):
-        result = handle_request(
-            action="run",
-            input="# Report",
-            from_fmt="MD",
-            to_fmt="PDF"
-        )
-        self.assertTrue(result.startswith("Error: Conversion failed locally:"))
-        self.assertIn("Local fallback for PDF is not supported", result)
+    def test_markdown_to_docx_and_reverse(self):
+        md_text = """# Project Title
+## Subheading
+This is a paragraph with **bold** text and *italic* text.
+
+- List item 1
+- List item 2
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_path = os.path.join(tmpdir, "test.docx")
+            res = handle_request(
+                action="run",
+                input=md_text,
+                from_fmt="MD",
+                to_fmt="DOCX",
+                save_to=save_path
+            )
+            self.assertTrue(os.path.exists(save_path))
+
+            # Reverse convert DOCX -> MD
+            rev_md = handle_request(
+                action="run",
+                input=save_path,
+                from_fmt="DOCX",
+                to_fmt="MD"
+            )
+            self.assertIn("Project Title", rev_md)
+            self.assertIn("Subheading", rev_md)
+            self.assertIn("List item 1", rev_md)
+
+    def test_markdown_to_epub_and_reverse(self):
+        md_text = """# E-book Title
+By Butler
+
+Welcome to the digital world.
+- Chapter One
+- Chapter Two
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_path = os.path.join(tmpdir, "test.epub")
+            res = handle_request(
+                action="run",
+                input=md_text,
+                from_fmt="MD",
+                to_fmt="EPUB",
+                save_to=save_path
+            )
+            self.assertTrue(os.path.exists(save_path))
+
+            # Ensure zipfile signature of standard epub
+            self.assertTrue(zipfile.is_zipfile(save_path))
+            with zipfile.ZipFile(save_path, 'r') as zf:
+                files = zf.namelist()
+                self.assertIn("mimetype", files)
+                self.assertIn("OEBPS/content.opf", files)
+                self.assertIn("OEBPS/chapter1.xhtml", files)
+
+    def test_markdown_to_image_drawing(self):
+        md_text = """# Drawing Title
+This is some drawing text to fit standard wrapping.
+- Draw line 1
+- Draw line 2
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_path = os.path.join(tmpdir, "test.png")
+            res = handle_request(
+                action="run",
+                input=md_text,
+                from_fmt="MD",
+                to_fmt="PNG",
+                save_to=save_path
+            )
+            self.assertTrue(os.path.exists(save_path))
+
+            # Read image and verify bytes size > 0
+            self.assertTrue(os.path.getsize(save_path) > 100)
+
+    def test_html_to_markdown_reverse(self):
+        html_text = """<h1>Web Title</h1>
+<p>Hello this is <strong>strong</strong> text and <em>em</em> text.</p>
+<ul>
+  <li>Bullet item A</li>
+  <li>Bullet item B</li>
+</ul>"""
+        md = html_to_markdown(html_text)
+        self.assertIn("Web Title", md)
+        self.assertIn("**strong**", md)
+        self.assertIn("*em*", md)
+        # Bullet list is also matched as standard bullet character
+        self.assertTrue(any(x in md for x in ["- Bullet item A", "* Bullet item A"]))
+
+    def test_cross_conversion_html_to_docx(self):
+        html_text = """<h1>Cross Conversion Header</h1>
+<p>This is a paragraph.</p>"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_path = os.path.join(tmpdir, "cross.docx")
+            res = handle_request(
+                action="run",
+                input=html_text,
+                from_fmt="HTML",
+                to_fmt="DOCX",
+                save_to=save_path
+            )
+            self.assertTrue(os.path.exists(save_path))
+
+            # Reverse docx to md
+            md = docx_to_markdown(save_path)
+            self.assertIn("Cross Conversion Header", md)
 
 
 if __name__ == "__main__":

--- a/verification/verify_document_studio.py
+++ b/verification/verify_document_studio.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import time
+from playwright.sync_api import sync_playwright
+
+def run_cuj(page):
+    # Navigate to the local document studio server
+    page.goto("http://127.0.0.1:8011")
+    page.wait_for_timeout(1000)
+
+    # Click the "实时预览" (Live Preview) tab
+    page.get_by_role("button", name="实时预览").click()
+    page.wait_for_timeout(1000)
+
+    # Click back to "编辑" (Edit) tab
+    page.get_by_role("button", name="编辑").click()
+    page.wait_for_timeout(500)
+
+    # Fill title and author
+    page.locator("#doc-title").fill("Butler Security Audit Report")
+    page.wait_for_timeout(500)
+    page.locator("#doc-author").fill("Agent Jules")
+    page.wait_for_timeout(500)
+
+    # Select Cyberpunk Dark theme
+    page.locator("#doc-theme").select_option("dark")
+    page.wait_for_timeout(500)
+
+    # Toggle theme on top right header
+    page.locator("#theme-toggle").click()
+    page.wait_for_timeout(1000)
+
+    # Take screenshot of the gorgeous glassmorphic workspace
+    os.makedirs("/home/jules/verification/screenshots", exist_ok=True)
+    screenshot_path = "/home/jules/verification/screenshots/document_studio.png"
+    page.screenshot(path=screenshot_path)
+    print(f"[+] Visually verified and screenshot captured at {screenshot_path}")
+    page.wait_for_timeout(1000)
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            record_video_dir="/home/jules/verification/videos"
+        )
+        page = context.new_page()
+        try:
+            run_cuj(page)
+        finally:
+            context.close()
+            browser.close()


### PR DESCRIPTION
Enables advanced any-to-any and reverse Markdown format conversions, with custom styled DOCX layout mapping, a pure-Python zero-dependency EPUB book packaging engine, dynamic text-wrapping long-image generation, programmatic PDF flowables, and a gorgeous glassmorphic web interactive workspace.

---
*PR created automatically by Jules for task [12004985190247820248](https://jules.google.com/task/12004985190247820248) started by @HelloEveryboby*

## Summary by Sourcery

添加一个高保真、以 Markdown 为中心的文档转换引擎，包含本地回退方案、反向转换器以及基于 Web 的文档工作室 UI，并将其集成到 CLI 和文件转换流水线中。

New Features:
- 支持通过新的纯 Python 导出器（带主题和可选水印）将 Markdown 转换为 DOCX、EPUB 和图像格式。
- 通过基于 markitdown 的流水线和轻量级回退方案，实现从 HTML、DOCX 和 PDF 反向转换回 Markdown。
- 暴露一个独立的 Butler Document Studio Web UI，用于交互式 Markdown 编辑和多格式导出，由 Flask API 提供后端支持。
- 在文档 `file_converter` 中新增格式路由，将受支持的路径委派给 Butler 高保真转换引擎。
- 引入一个 CLI 入口点，可直接从 `butler.py` 运行 `format_convert` 模块。

Enhancements:
- 优化 `format_convert` 技能，在可用时将特定转换任务路由到 Go runner，同时提供更丰富的本地回退逻辑，包括使用 ReportLab 进行基础 PDF 生成。
- 改进 `format_convert` 的输入处理，以支持文件路径、URL 和原始字节/文本，在合适的情况下通过 Markdown 作为中间格式进行归一化。
- 调整 Markdown 到 HTML 转换的默认主题和水印选项，以更好地匹配新的视觉风格。

Tests:
- 扩展 `format_convert` 的验证测试，覆盖 Markdown 到 DOCX、EPUB 和图像生成，以及 HTML 和 DOCX 的反向转换和基础 EPUB 结构校验。
- 添加基于 Playwright 的 CUJ 脚本，用于视觉验证 Document Studio Web UI，并捕获截图和视频。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a high-fidelity Markdown-centric document conversion engine with local fallbacks, reverse converters, and a web-based document studio UI, and integrate it into the CLI and file conversion pipeline.

New Features:
- Support converting Markdown to DOCX, EPUB, and image formats via new pure-Python exporters with theming and optional watermarking.
- Enable reverse conversions from HTML, DOCX, and PDF back to Markdown using markitdown-based pipelines and lightweight fallbacks.
- Expose a standalone Butler Document Studio web UI for interactive Markdown editing and multi-format export, backed by a Flask API.
- Add new format routing in the document file_converter to delegate supported paths to the Butler high-fidelity converter engine.
- Introduce a CLI entrypoint to run the format_convert module directly from butler.py.

Enhancements:
- Refine the format_convert skill to route certain conversions through the Go runner when available, while providing richer local fallback logic including basic PDF generation with ReportLab.
- Improve input handling in format_convert to support file paths, URLs, and raw bytes/text, normalizing through Markdown as an intermediate format where appropriate.
- Adjust default theming and watermark options for Markdown-to-HTML conversion to better match the new visual style.

Tests:
- Expand verification tests for format_convert to cover Markdown-to-DOCX, EPUB, and image generation, as well as HTML and DOCX reverse conversions and basic EPUB structure validation.
- Add a Playwright-based CUJ script to visually verify the Document Studio web UI and capture screenshots and videos.

</details>